### PR TITLE
Fix f-string syntax error in doc context

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2572,9 +2572,10 @@ class DiscordBot(commands.Bot):
 
             # Add fetched Google Doc content if available
             if google_doc_context_str:
+                google_docs_content = "\n\n".join(google_doc_context_str)
                 messages.append({
                     "role": "system",
-                    "content": f"Content from Google Docs linked in the query:\n\n{'\n\n'.join(google_doc_context_str)}"
+                    "content": f"Content from Google Docs linked in the query:\n\n{google_docs_content}"
                 })
 
             # Add channel context

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -239,9 +239,10 @@ def register_commands(bot):
 
             # Add fetched Google Doc content if available
             if google_doc_context:
+                google_docs_content = "\n\n".join(google_doc_context)
                 messages.append({
                     "role": "system",
-                    "content": f"Content from Google Docs linked in the query:\n\n{'\n\n'.join(google_doc_context)}"
+                    "content": f"Content from Google Docs linked in the query:\n\n{google_docs_content}"
                 })
 
             # --- Add Keyword Context ---


### PR DESCRIPTION
## Summary
- fix f-string syntax error when embedding Google Doc content
- adjust query command to avoid invalid f-string expression

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ffeb14908326b50341f49951e73d