### PR TITLE
Fix default CHUNK_SIZE comment

### DIFF
--- a/managers/config.py
+++ b/managers/config.py
@@ -26,7 +26,7 @@ class Config:
         self.EMBEDDING_DIMENSIONS = int(os.getenv('EMBEDDING_DIMENSIONS', '0'))
         
         # Chunk size configuration
-        self.CHUNK_SIZE = int(os.getenv('CHUNK_SIZE', '300'))  # Default to 750 words per chunk
+        self.CHUNK_SIZE = int(os.getenv('CHUNK_SIZE', '300'))  # Default to 300 words per chunk
         self.CHUNK_OVERLAP = int(os.getenv('CHUNK_OVERLAP', '30'))  # Default to 125 words overlap
         
         # TOP_K configuration with multiplier


### PR DESCRIPTION
## Summary
- correct comment in `config.py` to match the actual default of 300 words per chunk

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685601f4ac388326add9ea6e6dd305a5