### PR TITLE
Fix info prompt toggle bug

### DIFF
--- a/managers/preferences.py
+++ b/managers/preferences.py
@@ -143,9 +143,9 @@ class UserPreferencesManager:
 
     def toggle_informational_prompt_mode(self, user_id: str) -> bool:
         """Toggle the user's informational prompt mode preference and return the new state."""
+        preferences = {}
         try:
             file_path = self.get_file_path(user_id)
-            preferences = {}
             if os.path.exists(file_path):
                 try:
                     with open(file_path, 'r', encoding='utf-8') as file:

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -19,3 +19,11 @@ def test_toggle_debug_mode_with_faulty_path(tmp_path):
     manager.preferences_dir = None
     result = manager.toggle_debug_mode("user")
     assert result is False
+
+
+def test_toggle_info_prompt_with_faulty_path(tmp_path):
+    prefs = load_preferences_module()
+    manager = prefs.UserPreferencesManager(base_dir=str(tmp_path))
+    manager.preferences_dir = None
+    result = manager.toggle_informational_prompt_mode("user")
+    assert result is False


### PR DESCRIPTION
## Summary
- avoid `UnboundLocalError` if preferences directory is invalid
- add regression test for `toggle_informational_prompt_mode`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685729585f308326bfde9389b0604b0f