### PR TITLE
Fix variable reference and closure update timing bug

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -288,8 +288,8 @@ async def process_cli_query(args: argparse.Namespace, config: Config, doc_manage
             raw_doc_contexts.append(f"From document '{doc}' (Chunk {chunk_index}/{total_chunks}) (similarity: {score:.2f}):\n{chunk}")
 
     # --- Prepare Messages for LLM ---
-    document_list_content = document_manager.get_document_list_content()
-    messages = [{"role": "system", "content": get_system_prompt_with_documents(document_list_content)}] # System prompt with document list
+    document_list_content = doc_manager.get_document_list_content()
+    messages = [{"role": "system", "content": get_system_prompt_with_documents(document_list_content)}]  # System prompt with document list
 
     # Add raw document context
     if raw_doc_contexts:

--- a/commands/document_commands.py
+++ b/commands/document_commands.py
@@ -656,6 +656,7 @@ def register_commands(bot):
             
             # Function to fetch messages in smaller batches with delays
             async def fetch_messages_carefully(limit=None):
+                nonlocal last_update_time
                 collected = []
                 last_id = None
                 remaining = limit


### PR DESCRIPTION
## Summary
- correct `document_list_content` retrieval in CLI to use `doc_manager`
- ensure archive status updates track elapsed time in `fetch_messages_carefully`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685729585f308326bfde9389b0604b0f