### PR TITLE
Add unit tests for helpers and conversation manager

### DIFF
--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1,0 +1,43 @@
+import json
+import os
+import importlib.util
+from pathlib import Path
+
+
+def load_conversation_module():
+    module_path = Path(__file__).resolve().parents[1] / "managers" / "conversation.py"
+    spec = importlib.util.spec_from_file_location("conversation", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+conversation = load_conversation_module()
+ConversationManager = conversation.ConversationManager
+
+
+def test_get_file_path_sanitization(tmp_path):
+    manager = ConversationManager(base_dir=str(tmp_path))
+    path = manager.get_file_path('User/../bad')
+    assert os.path.basename(path) == 'User..bad.json'
+
+
+def test_write_and_get_limited_history(tmp_path):
+    manager = ConversationManager(base_dir=str(tmp_path))
+    for i in range(5):
+        manager.write_conversation('user', 'user', f'msg {i}')
+    history = manager.get_limited_history('user', limit=3)
+    assert len(history) == 3
+    assert history[0]['display_index'] == 0
+    assert history[-1]['content'].endswith('msg 4')
+
+
+def test_delete_messages_by_display_index(tmp_path):
+    manager = ConversationManager(base_dir=str(tmp_path))
+    for i in range(5):
+        manager.write_conversation('user', 'user', f'msg {i}')
+    success, _, count = manager.delete_messages_by_display_index('user', [1], limit=3)
+    assert success is True
+    with open(manager.get_file_path('user'), 'r', encoding='utf-8') as f:
+        messages = json.load(f)
+    assert len(messages) == 4

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,64 @@
+import os
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import pytest
+
+
+def load_helpers_module():
+    module_path = Path(__file__).resolve().parents[1] / "utils" / "helpers.py"
+
+    # Stub discord and config dependencies to avoid heavy imports
+    if 'discord' not in sys.modules:
+        dummy_discord = types.ModuleType('discord')
+        dummy_discord.Interaction = object
+        app_cmds = types.ModuleType('discord.app_commands')
+        class DummyCheckFailure(Exception):
+            pass
+        app_cmds.CheckFailure = DummyCheckFailure
+        dummy_discord.app_commands = app_cmds
+        sys.modules['discord'] = dummy_discord
+        sys.modules['discord.app_commands'] = app_cmds
+
+    if 'managers.config' not in sys.modules:
+        config_mod = types.ModuleType('managers.config')
+        class DummyConfig:
+            ALLOWED_USER_IDS = []
+            ALLOWED_ROLE_IDS = []
+            def __init__(self):
+                self.DISCORD_BOT_TOKEN = 'x'
+                self.OPENROUTER_API_KEY = 'x'
+                self.GOOGLE_API_KEY = 'x'
+            def _validate_config(self):
+                pass
+        config_mod.Config = DummyConfig
+        sys.modules['managers.config'] = config_mod
+
+    spec = importlib.util.spec_from_file_location('helpers', module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+helpers = load_helpers_module()
+
+
+def test_sanitize_filename_basic():
+    assert helpers.sanitize_filename('test<invalid>.txt') == 'test_invalid_.txt'
+
+
+def test_sanitize_filename_reserved():
+    assert helpers.sanitize_filename('CON') == '_CON'
+
+
+def test_split_message_simple():
+    text = 'hello world'
+    assert helpers.split_message(text, max_length=20) == ['hello world']
+
+
+def test_split_message_long():
+    text = ('a' * 30 + '\n\n') * 10
+    chunks = helpers.split_message(text, max_length=50)
+    assert all(len(chunk) <= 50 for chunk in chunks)
+    assert ''.join(chunk.replace('\n', '') for chunk in chunks) .startswith('a' * 30)


### PR DESCRIPTION
## Summary
- add tests for utility functions in `utils.helpers`
- add tests for `ConversationManager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685729d7322c832681c1f3f83e09aa2a