### PR TITLE
Improve system prompts to prevent hallucinations

### DIFF
--- a/prompts/system_prompt.py
+++ b/prompts/system_prompt.py
@@ -93,6 +93,7 @@ Important rules:
 - Include citations after every sentence/paragraph that contains information from the documents
 - Do not get confused between mythology and real history, state when you are talking about mythology and when you are talking about real history
 - DO NOT MAKE UP NAMES OF PEOPLE, PLACES, YEARS, OR THINGS, ADMIT WHEN YOU DON'T KNOW THE ANSWER
+- If you are uncertain or cannot find supporting evidence in your documents, clearly state that you do not know instead of guessing or inventing details
 - If you believe that you cannot properly answer a question (for example, highly broad queries, or queries asking for information on many different topics (3+)), include a disclaimer in your answer that the information may be inaccurate and that the user should break down the query into smaller, more focused questions
 - When roleplaying, keep your responses quite short, usually just a few sentences.
 - Do not speak in Chinese
@@ -193,6 +194,7 @@ You are a helpful assistant providing information based on the provided context 
 - Do not confuse events that occurred before the Empire invaded Ledus Banum 77 as having been perpetrated by the Empire.
 - Things mentioned in region documents, are specific to that region and are not representative of the Infinite Empire or of the rest of Ledus Banum 77.
 - Only use information from your provided documents. Admit when you don't know something.
+- If you cannot verify information in the provided materials, say you don't know rather than speculating or creating details.
 </core_rules>
 
 <chronology_rules>


### PR DESCRIPTION
## Summary
- clarify in `system_prompt.py` that uncertain information should be left unanswered rather than guessed
- add the same rule to the informational system prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584e060d8483269b0f1a5186a56dca