### PR TITLE
Hide doc UUIDs from LLM context

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2518,7 +2518,7 @@ class DiscordBot(commands.Bot):
                 else:
                     # Display original_name for non-Google Docs
                     # The {special_note} variable is added before the {chunk}.
-                    raw_doc_contexts.append(f"From document '{original_name}' (UUID: `{doc_uuid}`, Chunk {chunk_index}/{total_chunks}) (similarity: {score:.2f}):\n{special_note}{chunk}")
+                    raw_doc_contexts.append(f"From document '{original_name}' (Chunk {chunk_index}/{total_chunks}) (similarity: {score:.2f}):\n{special_note}{chunk}")
                     
             # Add fetched Google Doc content to context
             google_doc_context_str = []

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -166,8 +166,7 @@ def register_commands(bot):
                     # Display original_name for non-Google Docs
                     raw_doc_contexts.append(
                         f"{preamble}"
-                        f"From document '{original_name}' (UUID: `{doc_uuid}`, "
-                        f"Chunk {chunk_index}/{total_chunks}) (similarity: {score:.2f}):\n{chunk}"
+                        f"From document '{original_name}' (Chunk {chunk_index}/{total_chunks}) (similarity: {score:.2f}):\n{chunk}"
                     )
 
             # Add fetched Google Doc content to context

--- a/managers/documents.py
+++ b/managers/documents.py
@@ -242,22 +242,29 @@ class DocumentManager:
                 if meta_val.get('original_name') == self._internal_list_doc_name:
                     internal_list_doc_uuid_to_skip = doc_uuid_key
                     break
-            
+
+            googledoc_mapping = self.get_original_name_to_googledoc_id_mapping()
+
             for doc_uuid, meta in self.metadata.items():
                 if doc_uuid == internal_list_doc_uuid_to_skip:
                     continue
                 original_name = meta.get('original_name', doc_uuid)
                 summary = meta.get('summary', 'No summary available.')
-                doc_items_for_list.append((original_name, doc_uuid, summary))
+                gdoc_id = googledoc_mapping.get(original_name)
+                doc_items_for_list.append((original_name, gdoc_id, summary))
 
-            doc_items_for_list.sort(key=lambda x: x[0]) 
+            doc_items_for_list.sort(key=lambda x: x[0])
             
             header = "List of Documents Available to Publicia\n=======================================\n\n"
             
             if doc_items_for_list:
                 content_lines = []
-                for original_name, doc_uuid, summary in doc_items_for_list:
-                    content_lines.append(f"- {original_name} (UUID: {doc_uuid})")
+                for original_name, gdoc_id, summary in doc_items_for_list:
+                    if gdoc_id:
+                        url = f"https://docs.google.com/document/d/{gdoc_id}/"
+                        content_lines.append(f"- {original_name} (Google Doc URL: {url})")
+                    else:
+                        content_lines.append(f"- {original_name}")
                     content_lines.append(f"  Summary: {summary}\n")
                 content = header + "\n".join(content_lines)
             else:
@@ -932,18 +939,24 @@ class DocumentManager:
             # If no internal list exists, generate a basic one
             logger.warning("Internal document list not found, generating basic list")
             doc_items = []
+            googledoc_mapping = self.get_original_name_to_googledoc_id_mapping()
             for doc_uuid, meta in self.metadata.items():
                 original_name = meta.get('original_name', doc_uuid)
                 summary = meta.get('summary', 'No summary available.')
-                doc_items.append((original_name, doc_uuid, summary))
+                gdoc_id = googledoc_mapping.get(original_name)
+                doc_items.append((original_name, gdoc_id, summary))
             
             doc_items.sort(key=lambda x: x[0])
             
             header = "List of Documents Available to Publicia\n=======================================\n\n"
             if doc_items:
                 content_lines = []
-                for original_name, doc_uuid, summary in doc_items:
-                    content_lines.append(f"- {original_name} (UUID: {doc_uuid})")
+                for original_name, gdoc_id, summary in doc_items:
+                    if gdoc_id:
+                        url = f"https://docs.google.com/document/d/{gdoc_id}/"
+                        content_lines.append(f"- {original_name} (Google Doc URL: {url})")
+                    else:
+                        content_lines.append(f"- {original_name}")
                     content_lines.append(f"  Summary: {summary}\n")
                 return header + "\n".join(content_lines)
             else:


### PR DESCRIPTION
## Summary
- avoid leaking document UUIDs to the LLM
- show Google Doc URLs in the internal document list when available
- omit UUIDs from search result context for both bot and CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a29bc01688326bd7d70dac0330c33