### PR TITLE
Add BM25 keyword search

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Comprehensive tools to help troubleshoot issues:
 | `/remove_doc` | Remove a document by its UUID (`doc_uuid`) |
 | `/search_docs` | Search documents directly |
 | `/search_keyword` | Find occurrences of a specific keyword |
+| `/search_keyword_bm25` | Keyword search ranked with BM25 |
 | `/add_googledoc` | Track a Google Doc |
 | `/list_googledocs` | List all tracked Google Docs |
 | `/remove_googledoc` | Remove a tracked Google Doc |

--- a/commands/utility_commands.py
+++ b/commands/utility_commands.py
@@ -30,7 +30,7 @@ def register_commands(bot):
             # Define standard command categories
             standard_categories = {
                 "Lore Queries": ["query", "query_full_context"],
-                "Document Management": ["list_docs", "search_docs", "search_keyword", "list_googledocs", "retrieve_file", "summarize_doc", "view_chunk"],
+                "Document Management": ["list_docs", "search_docs", "search_keyword", "search_keyword_bm25", "list_googledocs", "retrieve_file", "summarize_doc", "view_chunk"],
                 "Image Management": ["list_images", "view_image"],
                 "Utility": ["list_commands", "set_model", "get_model", "toggle_debug", "toggle_prompt_mode", "pronouns", "help", "whats_new"],
                 "Context/Memory Management": ["parse_channel", "history", "manage_history", "delete_history_messages", "swap_conversation", "list_archives", "archive_conversation", "delete_archive", "lobotomise", "memory_clear", "delete_history_messages"]

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -356,6 +356,8 @@ The bot will display a startup banner and initialize all components.
   - **Parameters**: `query` (The search term or question).
 - `/search_keyword`: Search for a specific keyword within documents.
   - **Parameters**: `keyword` (The word to search for).
+- `/search_keyword_bm25`: Search for a keyword using BM25 ranking.
+  - **Parameters**: `keyword` (The word to search for).
 
 - `/add_googledoc`: Track a Google Doc, linking it to an internal document UUID. **(Admin Only)**
   - **Parameters**: `doc_url` (The URL or ID of the Google Doc), `name` (Optional custom original name for this document in Publicia).

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -356,6 +356,8 @@ The bot will display a startup banner and initialize all components.
   - **Parameters**: `query` (The search term or question).
 - `/search_keyword`: Search for a specific keyword within documents.
   - **Parameters**: `keyword` (The word to search for).
+- `/search_keyword_bm25`: Search for a keyword using BM25 ranking.
+  - **Parameters**: `keyword` (The word to search for).
 
 - `/add_googledoc`: Track a Google Doc, linking it to an internal document UUID. **(Admin Only)**
   - **Parameters**: `doc_url` (The URL or ID of the Google Doc), `name` (Optional custom original name for this document in Publicia).


### PR DESCRIPTION
## Summary
- add `search_keyword_bm25` to `DocumentManager`
- add slash command `/search_keyword_bm25`
- document the new command in README and docs
- extend tests for BM25 search
- include new command in `/list_commands`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b3acfa1a08326961636cac521a82a