### PR TITLE
Add context info to QA logging

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2025,13 +2025,18 @@ class DiscordBot(commands.Bot):
         logger.info(f"Enhanced query with username: '{question}' -> '{enhanced_query}'")
         return enhanced_query
 
-    async def _get_channel_context(self, channel: discord.TextChannel, original_question: str) -> Optional[str]:
-        """Fetches and formats recent channel messages for context."""
+    async def _get_channel_context(self, channel: discord.TextChannel, original_question: str) -> Tuple[Optional[str], int]:
+        """Fetch and format recent channel messages for context.
+
+        Returns a tuple ``(context_str, count)`` where ``context_str`` is the
+        formatted context or ``None`` if no context was added, and ``count`` is
+        the number of messages used.
+        """
         channel_id = str(channel.id)
         parsing_enabled, message_count = self.user_preferences_manager.get_channel_parsing_settings(channel_id)
 
         if not (parsing_enabled and message_count > 0):
-            return None
+            return None, 0
 
         logger.info(f"Channel parsing enabled for {channel_id}. Fetching last {message_count} messages.")
         try:
@@ -2043,7 +2048,7 @@ class DiscordBot(commands.Bot):
 
             if not channel_messages:
                 logger.info("No recent channel messages found or fetched to add to context.")
-                return None
+                return None, 0
 
             # Format the channel messages for the AI
             formatted_channel_context = "Recent messages from this channel (for general context):\n"
@@ -2057,7 +2062,7 @@ class DiscordBot(commands.Bot):
                 logger.warning(f"Channel context truncated to {max_channel_context_len} characters.")
 
             logger.info(f"Added {len(channel_messages)} recent channel messages to context.")
-            return formatted_channel_context.strip()
+            return formatted_channel_context.strip(), len(channel_messages)
 
         except Exception as fetch_err:
             logger.error(f"Error fetching or formatting channel messages for context: {fetch_err}")
@@ -2614,8 +2619,9 @@ class DiscordBot(commands.Bot):
             messages.extend(conversation_messages)
 
             # --- Add Channel Parsing Context (if enabled) ---
+            channel_message_count = 0
             if message.guild:
-                channel_context = await self._get_channel_context(message.channel, original_question)
+                channel_context, channel_message_count = await self._get_channel_context(message.channel, original_question)
                 if channel_context:
                     messages.append({"role": "system", "content": channel_context})
             # --- End Channel Parsing Context ---
@@ -2867,6 +2873,16 @@ class DiscordBot(commands.Bot):
                     message.author.name, "assistant", response, channel_name
                 )
 
+                context_info = {
+                    "reply": referenced_message is not None,
+                    "direct_images": len(direct_image_attachments),
+                    "reply_images": len(referenced_image_attachments),
+                    "search_images": len(image_ids),
+                    "google_docs": len(google_doc_contents),
+                    "chunks": len(search_results),
+                    "channel_messages": channel_message_count,
+                }
+
                 log_qa_pair(
                     original_question,
                     response,
@@ -2874,6 +2890,7 @@ class DiscordBot(commands.Bot):
                     channel_name,
                     multi_turn=is_multiturn,
                     interaction_type="message",
+                    context=context_info,
                 )
 
                 # Send the response, replacing thinking message

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -440,6 +440,17 @@ def register_commands(bot):
                         user_id=str(interaction.user.id),
                         existing_message=status_message
                     )
+                    total_chunks = sum(len(chunks) for chunks in bot.document_manager.chunks.values())
+                    context_info = {
+                        "reply": False,
+                        "direct_images": 0,
+                        "reply_images": 0,
+                        "search_images": 0,
+                        "google_docs": 0,
+                        "chunks": total_chunks,
+                        "channel_messages": 0,
+                        "doc_count": len(all_doc_contents),
+                    }
                     log_qa_pair(
                         question,
                         response,
@@ -447,6 +458,7 @@ def register_commands(bot):
                         channel_name,
                         multi_turn=False,
                         interaction_type="slash_command",
+                        context=context_info,
                     )
                 else:
                     logger.error(f"Unexpected response structure: {completion}")
@@ -641,6 +653,17 @@ def register_commands(bot):
                         user_id=user_id_str,
                         existing_message=status_message
                     )
+                    total_chunks = sum(len(chunks) for chunks in bot.document_manager.chunks.values())
+                    context_info = {
+                        "reply": False,
+                        "direct_images": 0,
+                        "reply_images": 0,
+                        "search_images": 0,
+                        "google_docs": 0,
+                        "chunks": total_chunks,
+                        "channel_messages": 0,
+                        "doc_count": len(all_doc_contents),
+                    }
                     log_qa_pair(
                         question,
                         response,
@@ -648,6 +671,7 @@ def register_commands(bot):
                         channel_name,
                         multi_turn=False,
                         interaction_type="slash_command",
+                        context=context_info,
                     )
                 else:
                     logger.error(f"Unexpected response structure from full context query: {completion}")

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -97,9 +97,32 @@ def configure_logging():
 # File to store question/response pairs as JSON Lines
 QA_LOG_FILE = 'qa_log.jsonl'
 
+from typing import Optional, Dict, Any
+
+
 def log_qa_pair(question: str, response: str, username: str, channel: str = None,
-                multi_turn: bool = False, interaction_type: str = 'message'):
-    """Append a question/response pair to the QA log."""
+                multi_turn: bool = False, interaction_type: str = 'message',
+                context: Optional[Dict[str, Any]] = None):
+    """Append a question/response pair to the QA log.
+
+    Parameters
+    ----------
+    question: str
+        The user's question.
+    response: str
+        The bot's response.
+    username: str
+        Name of the user who asked the question.
+    channel: str, optional
+        Channel where the interaction happened.
+    multi_turn: bool
+        Whether this was part of a multi-turn conversation.
+    interaction_type: str
+        Type of interaction (e.g. "message" or "slash_command").
+    context: dict, optional
+        Additional context information about the request, such as number of
+        chunks or whether images were included.
+    """
     entry = {
         'timestamp': datetime.now().isoformat(),
         'username': username,
@@ -109,6 +132,14 @@ def log_qa_pair(question: str, response: str, username: str, channel: str = None
         'question': sanitize_for_logging(question),
         'response': sanitize_for_logging(response)
     }
+    if context:
+        sanitized_context = {}
+        for key, value in context.items():
+            if isinstance(value, str):
+                sanitized_context[key] = sanitize_for_logging(value)
+            else:
+                sanitized_context[key] = value
+        entry['context'] = sanitized_context
     try:
         with open(QA_LOG_FILE, 'a', encoding='utf-8') as f:
             f.write(json.dumps(entry, ensure_ascii=False) + '\n')


### PR DESCRIPTION
## Summary
- extend `log_qa_pair` to include optional context details
- capture channel message count when parsing channel context
- record context info (images, chunks, docs, etc.) when logging Q&A pairs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e9387d1f88326a0c58a48d86b97ff