### PR TITLE
Add model info to QA log

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2915,6 +2915,7 @@ class DiscordBot(commands.Bot):
                     multi_turn=is_multiturn,
                     interaction_type="message",
                     context=context_info,
+                    model_used=actual_model,
                 )
 
                 # Send the response, replacing thinking message

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -478,6 +478,7 @@ def register_commands(bot):
                         multi_turn=False,
                         interaction_type="slash_command",
                         context=context_info,
+                        model_used=actual_model,
                     )
                 else:
                     logger.error(f"Unexpected response structure: {completion}")
@@ -703,6 +704,7 @@ def register_commands(bot):
                         multi_turn=False,
                         interaction_type="slash_command",
                         context=context_info,
+                        model_used=actual_model or target_models[0],
                     )
                 else:
                     logger.error(f"Unexpected response structure from full context query: {completion}")

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -102,7 +102,8 @@ from typing import Optional, Dict, Any
 
 def log_qa_pair(question: str, response: str, username: str, channel: str = None,
                 multi_turn: bool = False, interaction_type: str = 'message',
-                context: Optional[Dict[str, Any]] = None):
+                context: Optional[Dict[str, Any]] = None,
+                model_used: Optional[str] = None):
     """Append a question/response pair to the QA log.
 
     Parameters
@@ -122,6 +123,8 @@ def log_qa_pair(question: str, response: str, username: str, channel: str = None
     context: dict, optional
         Additional context information about the request, such as number of
         chunks or whether images were included.
+    model_used: str, optional
+        The model that generated the response.
     """
     entry = {
         'timestamp': datetime.now().isoformat(),
@@ -132,6 +135,8 @@ def log_qa_pair(question: str, response: str, username: str, channel: str = None
         'question': sanitize_for_logging(question),
         'response': sanitize_for_logging(response)
     }
+    if model_used:
+        entry['model_used'] = sanitize_for_logging(model_used)
     if context:
         sanitized_context = {}
         for key, value in context.items():


### PR DESCRIPTION
## Summary
- log_qa_pair now accepts a `model_used` parameter and records it
- record the chosen model when logging query responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f25e0fe5483268447d88d1ac729d3