### PR TITLE
Add per-user temperature command

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The bot automatically adjusts response temperature based on query type:
 - Higher temperature for creative/roleplay scenarios
 - Base temperature for balanced queries
 - Detects context through analysis of roleplay elements, question markers, etc.
+- Customize your personal temperature range with the `/temperature` command. Values must satisfy `0.0 ≤ min ≤ base ≤ max ≤ 2.0`.
 
 ### Debugging and Logging
 Comprehensive tools to help troubleshoot issues:
@@ -234,6 +235,7 @@ Comprehensive tools to help troubleshoot issues:
 | `/help` | Display detailed help information |
 | `/toggle_prompt_mode` | Toggle between standard (immersive) and informational (concise) system prompts |
 | `/pronouns` | Set your preferred pronouns |
+| `/temperature` | Set your custom temperature range (0.0–2.0). Call with no values to reset to defaults |
 | `/whats_new` | Shows documents and images added or updated recently |
 
 #### Admin Commands

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -439,7 +439,8 @@ def register_commands(bot):
                     await status_message.edit(content=f"*analyzing query, search results, and channel context ({len(channel_messages)} messages)...*")
                     
             temperature = bot.calculate_dynamic_temperature(
-                question
+                question,
+                user_id=str(interaction.user.id)
             )
 
             completion, actual_model = await bot._try_ai_completion(
@@ -660,7 +661,10 @@ def register_commands(bot):
 
             await status_message.edit(content=f"*formulating response using {model_name_display}...*")
 
-            temperature = bot.calculate_dynamic_temperature(question) # Use dynamic temp
+            temperature = bot.calculate_dynamic_temperature(
+                question,
+                user_id=str(interaction.user.id)
+            )  # Use dynamic temp
 
             # Log the models being attempted
             logger.debug(f"Attempting full context query with models: {target_models}")

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -567,10 +567,11 @@ Configure the hybrid search system for optimal performance:
 
 The bot uses dynamic temperature control based on query type:
 
-- Edit TEMPERATURE_MIN (default: 0.0) for factual queries
-- Edit TEMPERATURE_BASE (default: 0.1) for balanced queries
-- Edit TEMPERATURE_MAX (default: 0.4) for creative roleplay
-- The bot automatically analyzes queries and conversation context to select appropriate temperature
+- Edit `TEMPERATURE_MIN` (default: 0.0) for factual queries
+- Edit `TEMPERATURE_BASE` (default: 0.1) for balanced queries
+- Edit `TEMPERATURE_MAX` (default: 0.4) for creative roleplay
+- You can override these values per user with the `/temperature` command (values must satisfy `0.0 ≤ min ≤ base ≤ max ≤ 2.0`; call with no values to reset to defaults)
+- The bot automatically analyzes queries and conversation context to select an appropriate temperature
 
 ### Reranking Configuration
 

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -567,10 +567,11 @@ Configure the hybrid search system for optimal performance:
 
 The bot uses dynamic temperature control based on query type:
 
-- Edit TEMPERATURE_MIN (default: 0.0) for factual queries
-- Edit TEMPERATURE_BASE (default: 0.1) for balanced queries
-- Edit TEMPERATURE_MAX (default: 0.4) for creative roleplay
-- The bot automatically analyzes queries and conversation context to select appropriate temperature
+- Edit `TEMPERATURE_MIN` (default: 0.0) for factual queries
+- Edit `TEMPERATURE_BASE` (default: 0.1) for balanced queries
+- Edit `TEMPERATURE_MAX` (default: 0.4) for creative roleplay
+- You can override these values per user with the `/temperature` command (values must satisfy `0.0 ≤ min ≤ base ≤ max ≤ 2.0`; call with no values to reset to defaults)
+- The bot automatically analyzes queries and conversation context to select an appropriate temperature
 
 ### Reranking Configuration
 

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -27,3 +27,38 @@ def test_toggle_info_prompt_with_faulty_path(tmp_path):
     manager.preferences_dir = None
     result = manager.toggle_informational_prompt_mode("user")
     assert result is False
+
+
+def test_set_temperature_with_faulty_path(tmp_path):
+    prefs = load_preferences_module()
+    manager = prefs.UserPreferencesManager(base_dir=str(tmp_path))
+    manager.preferences_dir = None
+    result = manager.set_temperature_settings("user", 0.0, 0.1, 0.4)
+    assert result is False
+
+
+def test_set_temperature_invalid_range(tmp_path):
+    prefs = load_preferences_module()
+    manager = prefs.UserPreferencesManager(base_dir=str(tmp_path))
+    # base higher than max should fail
+    result = manager.set_temperature_settings("user", 0.0, 0.8, 0.6)
+    assert result is False
+
+
+def test_set_temperature_valid_range(tmp_path):
+    prefs = load_preferences_module()
+    manager = prefs.UserPreferencesManager(base_dir=str(tmp_path))
+    result = manager.set_temperature_settings("user", 0.1, 0.2, 0.5)
+    assert result is True
+    temps = manager.get_temperature_settings("user")
+    assert temps == (0.1, 0.2, 0.5)
+
+
+def test_clear_temperature_settings(tmp_path):
+    prefs = load_preferences_module()
+    manager = prefs.UserPreferencesManager(base_dir=str(tmp_path))
+    manager.set_temperature_settings("user", 0.2, 0.3, 0.6)
+    cleared = manager.clear_temperature_settings("user")
+    assert cleared is True
+    temps = manager.get_temperature_settings("user")
+    assert temps == (None, None, None)


### PR DESCRIPTION
## Summary
- allow users to save a custom temperature range in preferences
- adjust dynamic temperature calculation to pull per-user settings
- provide a `/temperature` slash command for editing the range
- document the new command and update help text
- add tests for new preference manager method
- validate custom temperature ranges and reject invalid values
- allow `/temperature` with no arguments to reset to defaults
- note custom temperature command in features section

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861ecb2a4e8832684225bcf907d058a