### PR TITLE
Add temperature values to logs

### DIFF
--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -440,7 +440,7 @@ def register_commands(bot):
                     logger.debug(f"Added {len(channel_messages)} channel messages to context")
                     await status_message.edit(content=f"*analyzing query, search results, and channel context ({len(channel_messages)} messages)...*")
                     
-            temperature = bot.calculate_dynamic_temperature(
+            temperature, t_min, t_base, t_max = bot.calculate_dynamic_temperature(
                 question,
                 user_id=str(interaction.user.id)
             )
@@ -478,6 +478,10 @@ def register_commands(bot):
                         "chunk_details": chunk_details,
                         "channel_messages": 0,
                         "doc_count": doc_count,
+                        "temperature_min": t_min,
+                        "temperature_base": t_base,
+                        "temperature_max": t_max,
+                        "temperature_used": temperature,
                     }
                     log_qa_pair(
                         question,
@@ -488,6 +492,10 @@ def register_commands(bot):
                         interaction_type="slash_command",
                         context=context_info,
                         model_used=actual_model,
+                        temperature=temperature,
+                        temperature_min=t_min,
+                        temperature_base=t_base,
+                        temperature_max=t_max,
                     )
                 else:
                     logger.error(f"Unexpected response structure: {completion}")
@@ -663,7 +671,7 @@ def register_commands(bot):
 
             await status_message.edit(content=f"*formulating response using {model_name_display}...*")
 
-            temperature = bot.calculate_dynamic_temperature(
+            temperature, t_min, t_base, t_max = bot.calculate_dynamic_temperature(
                 question,
                 user_id=str(interaction.user.id)
             )  # Use dynamic temp
@@ -710,6 +718,10 @@ def register_commands(bot):
                         "chunk_details": chunk_details,
                         "channel_messages": 0,
                         "doc_count": len(all_doc_contents),
+                        "temperature_min": t_min,
+                        "temperature_base": t_base,
+                        "temperature_max": t_max,
+                        "temperature_used": temperature,
                     }
                     log_qa_pair(
                         question,
@@ -720,6 +732,10 @@ def register_commands(bot):
                         interaction_type="slash_command",
                         context=context_info,
                         model_used=actual_model or target_models[0],
+                        temperature=temperature,
+                        temperature_min=t_min,
+                        temperature_base=t_base,
+                        temperature_max=t_max,
                     )
                 else:
                     logger.error(f"Unexpected response structure from full context query: {completion}")

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -100,10 +100,20 @@ QA_LOG_FILE = 'qa_log.jsonl'
 from typing import Optional, Dict, Any
 
 
-def log_qa_pair(question: str, response: str, username: str, channel: str = None,
-                multi_turn: bool = False, interaction_type: str = 'message',
-                context: Optional[Dict[str, Any]] = None,
-                model_used: Optional[str] = None):
+def log_qa_pair(
+    question: str,
+    response: str,
+    username: str,
+    channel: str = None,
+    multi_turn: bool = False,
+    interaction_type: str = 'message',
+    context: Optional[Dict[str, Any]] = None,
+    model_used: Optional[str] = None,
+    temperature: Optional[float] = None,
+    temperature_min: Optional[float] = None,
+    temperature_base: Optional[float] = None,
+    temperature_max: Optional[float] = None,
+):
     """Append a question/response pair to the QA log.
 
     Parameters
@@ -125,6 +135,14 @@ def log_qa_pair(question: str, response: str, username: str, channel: str = None
         chunks or whether images were included.
     model_used: str, optional
         The model that generated the response.
+    temperature: float, optional
+        The actual temperature used for the response.
+    temperature_min: float, optional
+        The minimum allowed temperature at the time of generation.
+    temperature_base: float, optional
+        The base (default) temperature.
+    temperature_max: float, optional
+        The maximum allowed temperature at the time of generation.
     """
     entry = {
         'timestamp': datetime.now().isoformat(),
@@ -137,6 +155,14 @@ def log_qa_pair(question: str, response: str, username: str, channel: str = None
     }
     if model_used:
         entry['model_used'] = sanitize_for_logging(model_used)
+    if temperature is not None:
+        entry['temperature'] = temperature
+    if temperature_min is not None:
+        entry['temperature_min'] = temperature_min
+    if temperature_base is not None:
+        entry['temperature_base'] = temperature_base
+    if temperature_max is not None:
+        entry['temperature_max'] = temperature_max
     if context:
         sanitized_context = {}
         for key, value in context.items():


### PR DESCRIPTION
## Summary
- record temp settings in qa_log.jsonl
- log temp ranges in dynamic temperature calculation
- return temperature range from `calculate_dynamic_temperature`
- include temperature metadata when logging QA pairs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861ffdd2f908326866e1ffb0c2d1025