### PR TITLE
Add Markdown conversion for Google Docs

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -34,6 +34,7 @@ from utils.helpers import (
     split_message,
     sanitize_filename,
     xml_wrap,
+    html_to_markdown_without_base64,
 )
 from utils.logging import sanitize_for_logging, log_qa_pair
 from managers.keywords import KeywordManager # Added import
@@ -615,12 +616,14 @@ class DiscordBot(commands.Bot):
 
             # Download the latest version from Google
             async with aiohttp.ClientSession() as session:
-                url = f"https://docs.google.com/document/d/{doc_id}/export?format=txt"
+                url = f"https://docs.google.com/document/d/{doc_id}/export?format=html"
                 async with session.get(url) as response:
                     if response.status != 200:
                         logger.warning(f"Failed to download {doc_id} for change check (Status: {response.status}). Assuming changed.")
-                        return True # Assume changed if download fails
-                    new_content = await response.text()
+                        return True  # Assume changed if download fails
+                    html_content = await response.text()
+
+            new_content = html_to_markdown_without_base64(html_content)
 
             # Compute hash of the newly downloaded content
             import hashlib
@@ -720,20 +723,24 @@ class DiscordBot(commands.Bot):
             logger.warning(f"{log_prefix} Logic error: process_this_doc is false for GDoc ID {doc_id} ('{final_original_name}'), skipping.")
             return True, existing_internal_uuid 
 
-        # Download the document as TXT
         async with aiohttp.ClientSession() as session:
-            url = f"https://docs.google.com/document/d/{doc_id}/export?format=txt"
+            url = f"https://docs.google.com/document/d/{doc_id}/export?format=html"
             async with session.get(url) as response:
                     if response.status != 200:
-                        logger.error(f"Failed to download GDoc ID {doc_id} ('{final_original_name}') as TXT: {response.status}")
+                        logger.error(f"Failed to download GDoc ID {doc_id} ('{final_original_name}') as HTML: {response.status}")
                         if interaction_for_feedback:
-                            try: await interaction_for_feedback.followup.send(f"Failed to download Google Doc ID {doc_id} ('{final_original_name}'). Status: {response.status}", ephemeral=True)
-                            except: pass
+                            try:
+                                await interaction_for_feedback.followup.send(
+                                    f"Failed to download Google Doc ID {doc_id} ('{final_original_name}'). Status: {response.status}",
+                                    ephemeral=True,
+                                )
+                            except:
+                                pass
                         return False, None
-                    txt_content = await response.text()
+                    html_content = await response.text()
 
-        final_content = txt_content 
-        content_source_log = "original TXT"
+        final_content = html_to_markdown_without_base64(html_content)
+        content_source_log = "converted HTML"
 
         # Optional DOCX Processing
         if self.config.AUTO_PROCESS_GOOGLE_DOCS and "region" in final_original_name.lower(): # Use final_original_name
@@ -753,7 +760,7 @@ class DiscordBot(commands.Bot):
                                         f_docx.write(chunk)
                                 processed_docx_content = tag_lore_in_docx(str(docx_temp_path))
                                 if processed_docx_content:
-                                    final_content = processed_docx_content
+                                    final_content = html_to_markdown_without_base64(processed_docx_content)
                                     content_source_log = "processed DOCX"
                                 else: logger.warning(f"DOCX processing failed for {doc_id}, using TXT.")
                             else: logger.error(f"Failed to download DOCX for {doc_id}: {response_docx.status}")
@@ -862,16 +869,16 @@ class DiscordBot(commands.Bot):
     async def _fetch_google_doc_content(self, doc_id: str) -> Optional[str]:
         """Fetch the content of a Google Doc without tracking it."""
         try:
-            # Download the document
             async with aiohttp.ClientSession() as session:
-                url = f"https://docs.google.com/document/d/{doc_id}/export?format=txt"
+                url = f"https://docs.google.com/document/d/{doc_id}/export?format=html"
                 async with session.get(url) as response:
                     if response.status != 200:
                         logger.error(f"Failed to download {doc_id}: {response.status}")
                         return None
-                    content = await response.text()
-            
-            return content
+                    html_content = await response.text()
+
+            markdown_content = html_to_markdown_without_base64(html_content)
+            return markdown_content
                 
         except Exception as e:
             logger.error(f"Error downloading doc {doc_id}: {e}")

--- a/requirements.json
+++ b/requirements.json
@@ -13,6 +13,8 @@
     "uuid": "^1.30",
     "deque": "^1.0",
     "google-generativeai": "^0.3.0"
+    ,"markdownify": "^0.11.6"
+    ,"beautifulsoup4": "^4.9.0"
   },
   "python_version": ">=3.8",
   "description": "Dependencies for the Publicia Discord Bot"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ uuid>=1.30
 google-generativeai>=0.3.0
 rank_bm25
 python-docx>=1.1.0
+markdownify>=0.11.6
+beautifulsoup4>=4.9.0

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -7,6 +7,13 @@ import discord
 from discord import app_commands
 from managers.config import Config  # Import the Config class
 
+try:
+    from markdownify import markdownify as md  # type: ignore
+    from bs4 import BeautifulSoup  # type: ignore
+    MARKDOWNIFY_AVAILABLE = True
+except Exception:
+    MARKDOWNIFY_AVAILABLE = False
+
 # Instantiate Config to access settings
 config = Config()
 
@@ -193,6 +200,21 @@ def split_message(text, max_length=1750):
         chunks.append(current_chunk)
     
     return chunks
+
+
+def html_to_markdown_without_base64(html_content: str) -> str:
+    """Convert HTML to Markdown while stripping base64 images."""
+    if not MARKDOWNIFY_AVAILABLE:
+        return html_content
+
+    soup = BeautifulSoup(html_content, "html.parser")
+    for img in soup.find_all("img"):
+        src = img.get("src", "")
+        if src.startswith("data:"):
+            alt_text = img.get("alt", "")
+            img.replace_with(alt_text)
+
+    return md(str(soup))
 
 
 # --- End of module ---


### PR DESCRIPTION
## Summary
- convert Google Doc HTML to Markdown with helper
- download docs as HTML and store markdown
- strip base64 images from converted documents
- update requirements with markdownify and bs4

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607901f06c83268cfe9a4ddd3c89f2