### PR TITLE
Set debug mode enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,9 @@ The bot automatically adjusts response temperature based on query type:
 - Base temperature for balanced queries
 - Detects context through analysis of roleplay elements, question markers, etc.
 - Customize your personal temperature range with the `/temperature` command. Values must satisfy `0.0 ≤ min ≤ base ≤ max ≤ 2.0`.
-
 ### Debugging and Logging
 Comprehensive tools to help troubleshoot issues:
-- Toggle debug mode to show which model generated responses
+- Debug mode is **ON** by default and shows which model generated responses. Use `/toggle_debug` to hide this information
 - Export prompts to see exactly what's being sent to the models
 - Detailed logs for tracking operations and errors
 - Performance monitoring and optimization

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -559,7 +559,7 @@ Configure the hybrid search system for optimal performance:
 
 ### Debug Tools
 
--   **`/toggle_debug`**: Shows the specific AI model used for each response and potentially other metadata.
+-   **`/toggle_debug`**: Debug mode is ON by default and shows the specific AI model used for each response. Use this command to toggle the display.
 -   **Logs**: Check `bot_detailed.log` for detailed operational information, errors, and search process steps.
 -   **Admin Commands**: `/reload_docs`, `/regenerate_embeddings` are crucial for maintenance and applying configuration changes.
 
@@ -636,10 +636,10 @@ Customize search result reranking with these settings:
 
 ### Logging and Debugging
 
-The bot uses a comprehensive logging system:
+- The bot uses a comprehensive logging system:
 
 - Logs are stored in `bot_detailed.log`
-- Enable debug mode with `/toggle_debug` for model information
+- Debug mode is enabled by default and shows model information. Use `/toggle_debug` to disable it
 - Check console output for detailed errors
 - Image and document operations are logged extensively
 

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -559,7 +559,7 @@ Configure the hybrid search system for optimal performance:
 
 ### Debug Tools
 
--   **`/toggle_debug`**: Shows the specific AI model used for each response and potentially other metadata.
+-   **`/toggle_debug`**: Debug mode is ON by default and shows the specific AI model used for each response. Use this command to toggle the display.
 -   **Logs**: Check `bot_detailed.log` for detailed operational information, errors, and search process steps.
 -   **Admin Commands**: `/reload_docs`, `/regenerate_embeddings` are crucial for maintenance and applying configuration changes.
 
@@ -636,10 +636,10 @@ Customize search result reranking with these settings:
 
 ### Logging and Debugging
 
-The bot uses a comprehensive logging system:
+- The bot uses a comprehensive logging system:
 
 - Logs are stored in `bot_detailed.log`
-- Enable debug mode with `/toggle_debug` for model information
+- Debug mode is enabled by default and shows model information. Use `/toggle_debug` to disable it
 - Check console output for detailed errors
 - Image and document operations are logged extensively
 

--- a/managers/preferences.py
+++ b/managers/preferences.py
@@ -89,17 +89,17 @@ class UserPreferencesManager:
             return False
 
     def get_debug_mode(self, user_id: str) -> bool:
-        """Get the user's debug mode preference, default is False."""
+        """Get the user's debug mode preference, default is True."""
         file_path = self.get_file_path(user_id)
         if not os.path.exists(file_path):
-            return False
+            return True
         try:
             with open(file_path, 'r', encoding='utf-8') as file:
                 preferences = json.load(file)
-                return preferences.get("debug_mode", False)
+                return preferences.get("debug_mode", True)
         except Exception as e:
             logger.error(f"Error reading debug mode preference for {user_id}: {e}")
-            return False
+            return True
 
     def toggle_debug_mode(self, user_id: str) -> bool:
         """Toggle the user's debug mode preference and return the new state."""
@@ -116,7 +116,7 @@ class UserPreferencesManager:
                     )
                     preferences = {}  # Reset if invalid
 
-            current_mode = preferences.get("debug_mode", False)
+            current_mode = preferences.get("debug_mode", True)
             new_mode = not current_mode
             preferences["debug_mode"] = new_mode
 


### PR DESCRIPTION
## Summary
- default `debug_mode` preference to `True`
- describe new default debug behaviour in the README and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680f4789788326b784feae30e19996