### PR TITLE
Add channel contextualization toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ RERANKING_FILTER_MODE=strict # Options: strict, dynamic, topk
 CONTEXTUALIZATION_ENABLED=true # Enable AI-generated context for chunks
 MAX_WORDS_FOR_CONTEXT=20000 # Maximum words to consider for context generation
 USE_CONTEXTUALISED_CHUNKS=true # Use contextualized chunks in prompts
+CHANNEL_CONTEXTUALIZATION_ENABLED=true # Contextualize channel archives
 
 # Feature toggles
 KEYWORD_DATABASE_ENABLED=true # Enable keyword database system

--- a/commands/document_commands.py
+++ b/commands/document_commands.py
@@ -958,7 +958,11 @@ def register_commands(bot):
             for original_doc_name, doc_content_to_save in documents:
                 # Add to document manager, which returns the UUID
                 # The original_doc_name here will be like "channel_archive_general_20230101_1200_part1.txt"
-                doc_uuid_assigned = await bot.document_manager.add_document(original_name=original_doc_name, content=doc_content_to_save)
+                doc_uuid_assigned = await bot.document_manager.add_document(
+                    original_name=original_doc_name,
+                    content=doc_content_to_save,
+                    contextualize=getattr(bot.config, 'CHANNEL_CONTEXTUALIZATION_ENABLED', True)
+                )
                 
                 if not doc_uuid_assigned:
                     logger.error(f"Failed to add archived document part '{original_doc_name}' to DocumentManager.")

--- a/commands/tracking_commands.py
+++ b/commands/tracking_commands.py
@@ -83,7 +83,7 @@ async def update_tracked_channels(bot_instance):
                 original_name=original_name,
                 content=archive_content,
                 existing_uuid=doc_uuid,
-                contextualize=True,
+                contextualize=getattr(bot_instance.config, 'CHANNEL_CONTEXTUALIZATION_ENABLED', True),
             )
 
             if update_success:
@@ -128,7 +128,9 @@ def register_commands(bot):
         initial_content, msg_count = await _build_channel_archive(channel)
 
         doc_uuid = await bot.document_manager.add_document(
-            original_name=doc_name, content=initial_content, contextualize=True
+            original_name=doc_name,
+            content=initial_content,
+            contextualize=getattr(bot.config, 'CHANNEL_CONTEXTUALIZATION_ENABLED', True)
         )
 
         if not doc_uuid:

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -289,6 +289,7 @@ RERANKING_FILTER_MODE=strict # Options: strict, dynamic, topk
 CONTEXTUALIZATION_ENABLED=true # Enable AI-generated context for chunks
 MAX_WORDS_FOR_CONTEXT=20000 # Maximum words to consider for context generation
 USE_CONTEXTUALISED_CHUNKS=true # Use contextualized chunks in prompts
+CHANNEL_CONTEXTUALIZATION_ENABLED=true # Contextualize channel archives
 
 # Feature toggles
 KEYWORD_DATABASE_ENABLED=true # Enable keyword database system

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -289,6 +289,7 @@ RERANKING_FILTER_MODE=strict # Options: strict, dynamic, topk
 CONTEXTUALIZATION_ENABLED=true # Enable AI-generated context for chunks
 MAX_WORDS_FOR_CONTEXT=20000 # Maximum words to consider for context generation
 USE_CONTEXTUALISED_CHUNKS=true # Use contextualized chunks in prompts
+CHANNEL_CONTEXTUALIZATION_ENABLED=true # Contextualize channel archives
 
 # Feature toggles
 KEYWORD_DATABASE_ENABLED=true # Enable keyword database system

--- a/documentation/channel_tracking_feature.md
+++ b/documentation/channel_tracking_feature.md
@@ -41,5 +41,5 @@ Two new slash commands have been introduced for managing channel tracking:
 3.  **Tracking Storage**: The channel's ID, the associated document UUID, and the last message ID are stored in a `tracked_channels.json` file.
 4.  **Periodic Updates**: The background task reads `tracked_channels.json` and, for each entry, fetches new messages from the channel using the last saved message ID as a starting point.
 5.  **Appending Content**: New messages are appended to the document file identified by the stored UUID.
-6.  **Embedding Update**: The entire document is re-processed to update its search embeddings. As of the latest update, channel archives are contextualized during this process so that each chunk is summarized before embedding, improving accuracy when querying these logs.
+6.  **Embedding Update**: The entire document is re-processed to update its search embeddings. If `CHANNEL_CONTEXTUALIZATION_ENABLED` is `true`, channel archives are contextualized during this process so each chunk is summarized before embedding. Disable this environment variable to skip contextualization for channel logs.
 7.  **Untracking**: Using `/untrack_channel` removes the corresponding entry from `tracked_channels.json`, effectively stopping the update cycle for that channel.

--- a/managers/config.py
+++ b/managers/config.py
@@ -151,6 +151,7 @@ class Config:
         self.CONTEXTUALIZATION_ENABLED = bool(os.getenv('CONTEXTUALIZATION_ENABLED', 'True').lower() in ('true', '1', 'yes'))
         self.MAX_WORDS_FOR_CONTEXT = int(os.getenv('MAX_WORDS_FOR_CONTEXT', '20000'))
         self.USE_CONTEXTUALISED_CHUNKS = bool(os.getenv('USE_CONTEXTUALISED_CHUNKS', 'True').lower() in ('true', '1', 'yes'))
+        self.CHANNEL_CONTEXTUALIZATION_ENABLED = bool(os.getenv('CHANNEL_CONTEXTUALIZATION_ENABLED', 'True').lower() in ('true', '1', 'yes'))
 
     def get_reranking_settings_for_query(self, query: str):
         """Get adaptive reranking settings based on query complexity."""


### PR DESCRIPTION
## Summary
- add `CHANNEL_CONTEXTUALIZATION_ENABLED` setting in config
- respect the new toggle when archiving or tracking channels
- document the new environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68692f17d8c88326a8fd672f7117f461