### PR TITLE
Fix missing tracked_header_row default

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -914,6 +914,7 @@ class DiscordBot(commands.Bot):
         final_original_name = None
         existing_internal_uuid = None
         name_from_tracking_file = None
+        tracked_header_row = header_row
 
         tracked_file = self.document_manager.base_dir / "tracked_google_sheets.json"
         if tracked_file.exists():


### PR DESCRIPTION
## Summary
- ensure `refresh_single_google_sheet` initializes `tracked_header_row`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701483cbdc8326968838f99b098830