### PR TITLE
Refine document prompt layout

### DIFF
--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -55,6 +55,15 @@ def xml_wrap(tag: str, content: str) -> str:
     return f"<{tag}>{content}</{tag}>"
 
 
+def wrap_document(content: str, source: str, metadata: str = "") -> str:
+    """Wrap a document's content and source in structured XML tags."""
+    meta_section = f"\n<metadata>{metadata}</metadata>" if metadata else ""
+    return (
+        f"<document>\n<source>{source}</source>{meta_section}\n"
+        f"<document_content>\n{content}\n</document_content>\n</document>"
+    )
+
+
 async def check_permissions(ctx):
     """
     Check if a user has permissions for a command, compatible with both


### PR DESCRIPTION
## Summary
- add `wrap_document` helper to create XML-wrapped document blocks
- insert document context before instructions when building query prompts
- restructure full-context queries to wrap documents and place them first
- use `wrap_document` in document manager utilities
- add fallback wrapper for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701fff2a3c8326951a440c3afcdd62