### PR TITLE
Add Switchpoint router model

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Users can select their preferred AI model for responses:
 - **Claude 4 Sonnet**: Premium capabilities (admin restricted)
 - **Nous: Hermes 405B**: Balanced between creativity and precision
 - **Kimi K2**: Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing (not tested much yet)
+- **Switchpoint Router**: Instantly routes your request to the best available model from Switchpoint AI's evolving library
 - **Grok 3 Mini**: X.AI's efficient model for quick responses
 
 Additional admin-only models include Gemini 2.5 Pro, Claude 3.7 Sonnet, Anubis Pro 105B, Llama 4 Maverick, OpenAI GPT-4.1 models, and Phi-4 Multimodal.

--- a/bot.py
+++ b/bot.py
@@ -3117,6 +3117,7 @@ class DiscordBot(commands.Bot):
             elif "qwen/qwq-32b" in preferred_model: model_name = "Qwen QwQ 32B"
             elif "qwen/qwen3-235b-a22b" in preferred_model: model_name = "Qwen 3 235B A22B"
             elif "moonshotai/kimi-k2" in preferred_model: model_name = "Kimi K2"
+            elif "switchpoint/router" in preferred_model: model_name = "Switchpoint Router"
             elif "eva-unit-01/eva-qwen-2.5-72b" in preferred_model: model_name = "EVA Qwen 2.5 72B"
             elif "latitudegames/wayfarer" in preferred_model: model_name = "Wayfarer 70B"
             elif "thedrummer/anubis-pro" in preferred_model: model_name = "Anubis Pro 105B"
@@ -3131,6 +3132,8 @@ class DiscordBot(commands.Bot):
                 model_name = "OpenAI o4 Mini"
             elif preferred_model == "moonshot/kimi-k2":
                 model_name = "Kimi K2"
+            elif preferred_model == "switchpoint/router":
+                model_name = "Switchpoint Router"
             # Note: "Testing Model" name is less clear, using specific names if possible.
 
             # Update thinking message before API call

--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -110,6 +110,9 @@ def register_commands(bot):
                     "eva-unit-01/eva-qwen-2.5-72b",
                     "thedrummer/unslopnemo-12b",
                 ],
+                "switchpoint": [
+                    "switchpoint/router",
+                ],
                 "storytelling": [
                     "latitudegames/wayfarer-large-70b-llama-3.3",
                     "thedrummer/anubis-pro-105b-v1"

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -383,6 +383,8 @@ def register_commands(bot):
                 model_name = "Qwen 3 235B A22B"
             elif "moonshotai/kimi-k2" in preferred_model:
                 model_name = "Kimi K2"
+            elif "switchpoint/router" in preferred_model:
+                model_name = "Switchpoint Router"
             elif "unslopnemo" in preferred_model or "eva-unit-01/eva-qwen-2.5-72b" in preferred_model:
                 model_name = "Testing Model"
             elif "latitudegames/wayfarer" in preferred_model:

--- a/commands/utility_commands.py
+++ b/commands/utility_commands.py
@@ -166,6 +166,7 @@ def register_commands(bot):
         app_commands.Choice(name="OpenAI o4 Mini", value="openai/o4-mini"),
         app_commands.Choice(name="MiniMax M1", value="minimax/minimax-m1"),
         app_commands.Choice(name="Kimi K2", value="moonshotai/kimi-k2"),
+        app_commands.Choice(name="Switchpoint Router", value="switchpoint/router"),
         app_commands.Choice(name="Gemini 2.5 Flash", value="google/gemini-2.5-flash-preview:thinking"),
         #app_commands.Choice(name="Gemini 2.5 Pro", value="google/gemini-2.5-pro-preview-03-25"), # Added new model
         app_commands.Choice(name="Qwen QwQ 32B", value="qwen/qwq-32b"),
@@ -232,6 +233,8 @@ def register_commands(bot):
                 model_name = "Qwen 3 235B A22B"
             elif "moonshotai/kimi-k2" in model:
                 model_name = "Kimi K2"
+            elif "switchpoint/router" in model:
+                model_name = "Switchpoint Router"
             elif "unslopnemo" in model or "eva-unit-01/eva-qwen-2.5-72b" in model:
                 model_name = "Testing Model"
             elif "latitudegames/wayfarer" in model:
@@ -262,6 +265,7 @@ def register_commands(bot):
                     f"**OpenAI o4 Mini**: __RECOMMENDED__ An OpenAI model that is very good for factual accuracy, avoiding hallucinations, and speed of response. Uses ({bot.config.get_top_k_for_model('openai/o4-mini')}) search results.",
                     f"**MiniMax M1**: __RECOMMENDED__ A large-scale, open-weight reasoning model from MiniMax, good for general tasks and long-context understanding. Great for finding accurate information. Good prompt adherence and an interesting personality. Uses ({bot.config.get_top_k_for_model('minimax/minimax-m1')}) search results.",
                     f"**Kimi K2**: __RECOMMENDED__ An opensource Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing and accuracy. Uses ({bot.config.get_top_k_for_model('moonshotai/kimi-k2')}) search results.",
+                    f"**Switchpoint Router**: Instantly routes requests to the optimal model from Switchpoint AI's evolving library. Uses ({bot.config.get_top_k_for_model('switchpoint/router')}) search results.",
                     f"**Gemini 2.5 Flash**: - Fine for prompt adherence, accurate citations, image viewing capabilities, and fast response times. Prone to hallucinating if asked about something not in it's supplied documents. Uses more search results ({bot.config.get_top_k_for_model('google/gemini-2.5-flash-preview:thinking')}).",
                     #f"**Gemini 2.5 Pro**: (admin only) Uses ({bot.config.get_top_k_for_model('google/gemini-2.5-pro-preview-03-25')}) search results.",
                     f"**Qwen QwQ 32B**: __RECOMMENDED__ - Great for roleplaying and creativity with strong factual accuracy and in-character immersion. Produces detailed, nuanced responses with structured formatting. Uses ({bot.config.get_top_k_for_model('qwen/qwq-32b')}) search results.",
@@ -333,6 +337,8 @@ def register_commands(bot):
                 model_name = "Qwen 3 235B A22B"
             elif "moonshotai/kimi-k2" in preferred_model:
                 model_name = "Kimi K2"
+            elif "switchpoint/router" in preferred_model:
+                model_name = "Switchpoint Router"
             elif "unslopnemo" in preferred_model or "eva-unit-01/eva-qwen-2.5-72b" in preferred_model:
                 model_name = "Testing Model"
             elif "latitudegames/wayfarer" in preferred_model:
@@ -361,6 +367,7 @@ def register_commands(bot):
                     f"**OpenAI o4 Mini**: __RECOMMENDED__ An OpenAI model that is very good for factual accuracy, avoiding hallucinations, and speed of response. Uses ({bot.config.get_top_k_for_model('openai/o4-mini')}) search results.",
                     f"**MiniMax M1**: __RECOMMENDED__ A large-scale, open-weight reasoning model from MiniMax, good for general tasks and long-context understanding. Great for finding accurate information. Good prompt adherence and an interesting personality. Uses ({bot.config.get_top_k_for_model('minimax/minimax-m1')}) search results.",
                     f"**Kimi K2**: __RECOMMENDED__ An opensource Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing and accuracy. Uses ({bot.config.get_top_k_for_model('moonshotai/kimi-k2')}) search results.",
+                    f"**Switchpoint Router**: Instantly routes requests to the optimal model from Switchpoint AI's evolving library. Uses ({bot.config.get_top_k_for_model('switchpoint/router')}) search results.",
                     f"**Gemini 2.5 Flash**: - Fine for prompt adherence, accurate citations, image viewing capabilities, and fast response times. Prone to hallucinating if asked about something not in it's supplied documents. Uses more search results ({bot.config.get_top_k_for_model('google/gemini-2.5-flash-preview:thinking')}).",
                     #f"**Gemini 2.5 Pro**: (admin only) Uses ({bot.config.get_top_k_for_model('google/gemini-2.5-pro-preview-03-25')}) search results.",
                     f"**Qwen QwQ 32B**: __RECOMMENDED__ - Great for roleplaying and creativity with strong factual accuracy and in-character immersion. Produces detailed, nuanced responses with structured formatting. Uses ({bot.config.get_top_k_for_model('qwen/qwq-32b')}) search results.",

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -168,6 +168,7 @@ Users can choose their preferred AI model:
 - **Claude 4 Sonnet**: Premium capabilities (admin restricted)
 - **Nous: Hermes 405B**: Balanced between creativity and precision
 - **Kimi K2**: Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing (not tested much yet)
+- **Switchpoint Router**: Instantly routes your request to the optimal AI from an ever-evolving library
 - **Wayfarer 70B**: Optimized for narrative-driven roleplay
 - **Grok 3 Mini**: X.AI's efficient model for quick responses
 
@@ -518,6 +519,7 @@ Choose models based on your needs:
 - **Claude 4 Sonnet**: Advanced capabilities with enhanced creativity (admin-only)
 - **Nous: Hermes 405B**: Good middle-ground between creativity and precision
 - **Kimi K2**: Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing (not tested much yet)
+- **Switchpoint Router**: Instantly routes your request to the optimal AI from an ever-evolving library
 - **Wayfarer 70B**: Optimized for narrative-driven roleplay with realistic stakes and conflicts
 - **Grok 3 Mini**: X.AI's efficient model for quick, conversational responses
 

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -159,6 +159,7 @@ Users can choose their preferred AI model:
 - **Claude 4 Sonnet**: Premium capabilities (admin restricted)
 - **Nous: Hermes 405B**: Balanced between creativity and precision
 - **Kimi K2**: Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing (not tested much yet)
+- **Switchpoint Router**: Instantly routes your request to the optimal AI from an ever-evolving library
 - **Wayfarer 70B**: Optimized for narrative-driven roleplay
 - **Grok 3 Mini**: X.AI's efficient model for quick responses
 
@@ -502,6 +503,7 @@ Choose models based on your needs:
 - **Claude 4 Sonnet**: Advanced capabilities with enhanced creativity (admin-only)
 - **Nous: Hermes 405B**: Good middle-ground between creativity and precision
 - **Kimi K2**: Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing (not tested much yet)
+- **Switchpoint Router**: Instantly routes your request to the optimal AI from an ever-evolving library
 - **Wayfarer 70B**: Optimized for narrative-driven roleplay with realistic stakes and conflicts
 - **Grok 3 Mini**: X.AI's efficient model for quick, conversational responses
 

--- a/managers/config.py
+++ b/managers/config.py
@@ -88,6 +88,7 @@ class Config:
             "minimax/minimax-m1": 20,
             # Moonshot AI Models
             "moonshotai/kimi-k2": 20,
+            "switchpoint/router": 12,
         }
         
         # Validate required environment variables


### PR DESCRIPTION
## Summary
- add `switchpoint/router` to model top_k map
- mention Switchpoint Router as a model choice in README and documentation
- include Switchpoint Router in `/set_model` options and descriptions
- show Switchpoint friendly name inside bot
- allow Switchpoint Router in admin model comparisons
- handle Switchpoint Router inside bot and query command helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b2a1d9cc8326b8959b516c1aa391