### PR TITLE
Add OpenAI GPT-OSS 120B model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Users can select their preferred AI model for responses:
 - **Kimi K2**: Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing (not tested much yet)
 - **Switchpoint Router**: Instantly routes your request to the best available model from Switchpoint AI's evolving library
 - **Grok 3 Mini**: X.AI's efficient model for quick responses
+- **OpenAI GPT-OSS 120B**: Open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Serves as an open-source alternative to o4-mini, activates 5.1B parameters per pass, runs on a single H100 with MXFP4 quantization, and supports configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output)
 
 Additional admin-only models include Gemini 2.5 Pro, Claude 3.7 Sonnet, Anubis Pro 105B, Llama 4 Maverick, OpenAI GPT-4.1 models, and Phi-4 Multimodal.
 

--- a/bot.py
+++ b/bot.py
@@ -3145,6 +3145,8 @@ class DiscordBot(commands.Bot):
                 model_name = "MiniMax M1"
             elif preferred_model == "openai/o4-mini":
                 model_name = "OpenAI o4 Mini"
+            elif preferred_model == "openai/gpt-oss-120b":
+                model_name = "OpenAI GPT-OSS 120B"
             elif preferred_model == "moonshot/kimi-k2":
                 model_name = "Kimi K2"
             elif preferred_model == "switchpoint/router":

--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -106,6 +106,10 @@ def register_commands(bot):
                 "nous": [
                     "nousresearch/hermes-3-llama-3.1-405b",
                 ],
+                "openai": [
+                    "openai/o4-mini",
+                    "openai/gpt-oss-120b",
+                ],
                 "testing": [
                     "eva-unit-01/eva-qwen-2.5-72b",
                     "thedrummer/unslopnemo-12b",

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -421,6 +421,8 @@ def register_commands(bot):
                 model_name = "OpenAI GPT-4.1 Nano"
             elif preferred_model == "openai/o4-mini":
                 model_name = "OpenAI o4 Mini"
+            elif preferred_model == "openai/gpt-oss-120b":
+                model_name = "OpenAI GPT-OSS 120B"
             elif preferred_model == "minimax/minimax-m1":
                 model_name = "MiniMax M1"
 

--- a/commands/utility_commands.py
+++ b/commands/utility_commands.py
@@ -164,6 +164,7 @@ def register_commands(bot):
     @app_commands.describe(model="Choose the AI model you prefer")
     @app_commands.choices(model=[
         app_commands.Choice(name="OpenAI o4 Mini", value="openai/o4-mini"),
+        app_commands.Choice(name="OpenAI GPT-OSS 120B", value="openai/gpt-oss-120b"),
         app_commands.Choice(name="MiniMax M1", value="minimax/minimax-m1"),
         app_commands.Choice(name="Kimi K2", value="moonshotai/kimi-k2"),
         app_commands.Choice(name="Switchpoint Router", value="switchpoint/router"),
@@ -253,6 +254,8 @@ def register_commands(bot):
                 model_name = "OpenAI GPT-4.1 Mini"
             elif model == "openai/gpt-4.1-nano":
                 model_name = "OpenAI GPT-4.1 Nano"
+            elif model == "openai/gpt-oss-120b":
+                model_name = "OpenAI GPT-OSS 120B"
             elif model == "openai/o4-mini":
                 model_name = "OpenAI o4 Mini"
             elif model == "minimax/minimax-m1":
@@ -263,6 +266,7 @@ def register_commands(bot):
                 # Create a description of all model strengths
                 model_descriptions = [
                     f"**OpenAI o4 Mini**: __RECOMMENDED__ An OpenAI model that is very good for factual accuracy, avoiding hallucinations, and speed of response. Uses ({bot.config.get_top_k_for_model('openai/o4-mini')}) search results.",
+                    f"**OpenAI GPT-OSS 120B**: __RECOMMENDED__ An open-weight 117B-parameter Mixture-of-Experts model from OpenAI and open-source alternative to o4-mini. Activates 5.1B parameters per pass, optimized for a single H100 with MXFP4 quantization, and supports configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output). Uses ({bot.config.get_top_k_for_model('openai/gpt-oss-120b')}) search results.",
                     f"**MiniMax M1**: __RECOMMENDED__ A large-scale, open-weight reasoning model from MiniMax, good for general tasks and long-context understanding. Great for finding accurate information. Good prompt adherence and an interesting personality. Uses ({bot.config.get_top_k_for_model('minimax/minimax-m1')}) search results.",
                     f"**Kimi K2**: __RECOMMENDED__ An opensource Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing and accuracy. Uses ({bot.config.get_top_k_for_model('moonshotai/kimi-k2')}) search results.",
                     f"**Switchpoint Router**: Instantly routes requests to the optimal model from Switchpoint AI's evolving library. Uses ({bot.config.get_top_k_for_model('switchpoint/router')}) search results.",
@@ -357,6 +361,8 @@ def register_commands(bot):
                 model_name = "OpenAI GPT-4.1 Mini"
             elif preferred_model == "openai/gpt-4.1-nano":
                 model_name = "OpenAI GPT-4.1 Nano"
+            elif preferred_model == "openai/gpt-oss-120b":
+                model_name = "OpenAI GPT-OSS 120B"
             elif preferred_model == "openai/o4-mini":
                 model_name = "OpenAI o4 Mini"
             elif preferred_model == "minimax/minimax-m1":
@@ -365,6 +371,7 @@ def register_commands(bot):
             # Create a description of all model strengths
             model_descriptions = [
                     f"**OpenAI o4 Mini**: __RECOMMENDED__ An OpenAI model that is very good for factual accuracy, avoiding hallucinations, and speed of response. Uses ({bot.config.get_top_k_for_model('openai/o4-mini')}) search results.",
+                    f"**OpenAI GPT-OSS 120B**: __RECOMMENDED__ An open-weight 117B-parameter Mixture-of-Experts model from OpenAI and open-source alternative to o4-mini. Activates 5.1B parameters per pass, optimized for a single H100 with MXFP4 quantization, and supports configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output). Uses ({bot.config.get_top_k_for_model('openai/gpt-oss-120b')}) search results.",
                     f"**MiniMax M1**: __RECOMMENDED__ A large-scale, open-weight reasoning model from MiniMax, good for general tasks and long-context understanding. Great for finding accurate information. Good prompt adherence and an interesting personality. Uses ({bot.config.get_top_k_for_model('minimax/minimax-m1')}) search results.",
                     f"**Kimi K2**: __RECOMMENDED__ An opensource Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing and accuracy. Uses ({bot.config.get_top_k_for_model('moonshotai/kimi-k2')}) search results.",
                     f"**Switchpoint Router**: Instantly routes requests to the optimal model from Switchpoint AI's evolving library. Uses ({bot.config.get_top_k_for_model('switchpoint/router')}) search results.",

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -171,6 +171,7 @@ Users can choose their preferred AI model:
 - **Switchpoint Router**: Instantly routes your request to the optimal AI from an ever-evolving library
 - **Wayfarer 70B**: Optimized for narrative-driven roleplay
 - **Grok 3 Mini**: X.AI's efficient model for quick responses
+- **OpenAI GPT-OSS 120B**: Open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Functions as an open-source alternative to o4-mini, activating 5.1B parameters per pass, running on a single H100 with native MXFP4 quantization, and supporting configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output generation)
 
 Additional models available to administrators include Gemini 2.5 Pro, Claude 3.7 Sonnet, Anubis Pro 105B, Llama 4 Maverick, OpenAI GPT-4.1 models, and Phi-4 Multimodal.
 

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -162,6 +162,7 @@ Users can choose their preferred AI model:
 - **Switchpoint Router**: Instantly routes your request to the optimal AI from an ever-evolving library
 - **Wayfarer 70B**: Optimized for narrative-driven roleplay
 - **Grok 3 Mini**: X.AI's efficient model for quick responses
+- **OpenAI GPT-OSS 120B**: Open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Functions as an open-source alternative to o4-mini, activating 5.1B parameters per pass, running on a single H100 with native MXFP4 quantization, and supporting configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output generation)
 
 Additional models available to administrators include Gemini 2.5 Pro, Claude 3.7 Sonnet, Anubis Pro 105B, Llama 4 Maverick, OpenAI GPT-4.1 models, and Phi-4 Multimodal.
 

--- a/managers/config.py
+++ b/managers/config.py
@@ -82,6 +82,7 @@ class Config:
             "openai/gpt-4.1-mini": 11,
             "openai/gpt-4.1-nano": 17,
             "openai/o4-mini": 8,
+            "openai/gpt-oss-120b": 8,
             # X AI Models
             "x-ai/grok-3-mini-beta": 20,
             # MiniMax Models


### PR DESCRIPTION
## Summary
- include OpenAI's open-weight GPT-OSS 120B model across bot, query, and utility commands with friendly name and description
- document GPT-OSS 120B as an open-source alternative to o4-mini and add it to model comparison and configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68924ded9f308326873a2f03e45138a8