### PR TITLE
Add agentic query command with tool-powered search

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Comprehensive tools to help troubleshoot issues:
 | Command | Description |
 |---------|-------------|
 | `/query` | Ask a question with optional image URL |
+| `/agentic_query` | Ask a question using agentic tool-powered search |
 | `/history` | View your conversation history |
 | `/manage_history` | View and manage history with indices |
 | `/delete_history_messages` | Delete specific messages |

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -451,6 +451,8 @@ The bot will display a startup banner and initialize all components.
 
 - `/query`: Ask a question with optional image
   - **Parameters**: `question` (your query), `image_url` (optional)
+- `/agentic_query`: Ask a question using agentic tool-powered search
+  - **Parameters**: `question` (your query)
 
 - `/query_full_context`: Ask a question using ALL documents as context (1/day limit)
   - **Parameters**: `question` (your query)

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -436,6 +436,8 @@ The bot will display a startup banner and initialize all components.
 - `/query`: Ask a question with optional image
   - **Parameters**: `question` (your query), `image_url` (optional)
 
+- `/agentic_query`: Ask a question using agentic tool-powered search
+  - **Parameters**: `question` (your query)
 - `/query_full_context`: Ask a question using ALL documents as context (1/day limit)
   - **Parameters**: `question` (your query)
   - Uses powerful models like Gemini 2.5 Pro for comprehensive analysis.


### PR DESCRIPTION
## Summary
- add `/agentic_query` command that lets the model call search tools agentically
- expose search_keyword, search_bm25, search_embeddings and hybrid search functions as OpenRouter tools
- document new command in README and detailed documentation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689255e9f8408326a6112427f0bcdb0a