### PR TITLE
Add agentic query with tool-based search

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Comprehensive tools to help troubleshoot issues:
 | Command | Description |
 |---------|-------------|
 | `/query` | Ask a question with optional image URL |
-| `/agentic_query` | Ask a question using tool-powered search (starts with 5 chunks; tools fetch up to 5 each) |
+| `/agentic_query` | Ask a question using tool-powered search (starts with 5 chunks; tools fetch up to 5 each and can retrieve specific chunks) |
 | `/history` | View your conversation history |
 | `/manage_history` | View and manage history with indices |
 | `/delete_history_messages` | Delete specific messages |

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Comprehensive tools to help troubleshoot issues:
 | Command | Description |
 |---------|-------------|
 | `/query` | Ask a question with optional image URL |
+| `/agentic_query` | Ask a question using tool-powered search (starts with 5 chunks; tools fetch up to 5 each) |
 | `/history` | View your conversation history |
 | `/manage_history` | View and manage history with indices |
 | `/delete_history_messages` | Delete specific messages |

--- a/bot.py
+++ b/bot.py
@@ -2519,6 +2519,15 @@ class DiscordBot(commands.Bot):
         # #     )
         # #     return search_results
         #
+    @staticmethod
+    def _json_default(obj: Any):
+        """JSON serializer for non-standard types."""
+        if isinstance(obj, np.integer):
+            return int(obj)
+        if isinstance(obj, np.floating):
+            return float(obj)
+        return str(obj)
+
         #     # Search with this embedding and apply re-ranking
         #     # apply_reranking = self.config.RERANKING_ENABLED # Part of old logic
         #     #
@@ -2548,7 +2557,7 @@ class DiscordBot(commands.Bot):
         # #     )
         # #     return search_results # Part of old logic
 
-    async def _tool_search_keyword(self, keyword: str, top_k: int = 5):
+    async def _tool_search_keyword(self, keyword: str, top_k: int = 5) -> List[Dict[str, Any]]:
         """Tool: simple keyword search across documents."""
         requested_k = top_k
         top_k = min(top_k, 5)
@@ -2564,13 +2573,13 @@ class DiscordBot(commands.Bot):
                 "doc_uuid": doc_uuid,
                 "title": original_name,
                 "content": chunk,
-                "chunk_index": chunk_index,
-                "total_chunks": total_chunks,
+                "chunk_index": int(chunk_index),
+                "total_chunks": int(total_chunks),
             }
             for doc_uuid, original_name, chunk, chunk_index, total_chunks in results
         ]
 
-    async def _tool_search_keyword_bm25(self, keyword: str, top_k: int = 5):
+    async def _tool_search_keyword_bm25(self, keyword: str, top_k: int = 5) -> List[Dict[str, Any]]:
         """Tool: BM25 keyword search across documents."""
         requested_k = top_k
         top_k = min(top_k, 5)
@@ -2588,13 +2597,13 @@ class DiscordBot(commands.Bot):
                 "doc_uuid": doc_uuid,
                 "title": original_name,
                 "content": chunk,
-                "chunk_index": chunk_index,
-                "total_chunks": total_chunks,
+                "chunk_index": int(chunk_index),
+                "total_chunks": int(total_chunks),
             }
             for doc_uuid, original_name, chunk, chunk_index, total_chunks in results
         ]
 
-    async def _tool_search_documents(self, query: str, top_k: int = 5):
+    async def _tool_search_documents(self, query: str, top_k: int = 5) -> List[Dict[str, Any]]:
         """Tool: Hybrid embedding/BM25 search across documents."""
         requested_k = top_k
         top_k = min(top_k, 5)
@@ -2610,10 +2619,10 @@ class DiscordBot(commands.Bot):
                 "doc_uuid": doc_uuid,
                 "title": original_name,
                 "content": chunk,
-                "score": score,
-                "image_id": image_id,
-                "chunk_index": chunk_index,
-                "total_chunks": total_chunks,
+                "score": float(score),
+                "image_id": int(image_id) if image_id is not None else None,
+                "chunk_index": int(chunk_index),
+                "total_chunks": int(total_chunks),
             }
             for doc_uuid, original_name, chunk, score, image_id, chunk_index, total_chunks in results
         ]
@@ -2755,7 +2764,7 @@ class DiscordBot(commands.Bot):
                             "role": "tool",
                             "tool_call_id": call["id"],
                             "name": name,
-                            "content": json.dumps(result),
+                            "content": json.dumps(result, default=self._json_default),
                         }
                     )
                 continue

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -452,6 +452,9 @@ The bot will display a startup banner and initialize all components.
 - `/query`: Ask a question with optional image
   - **Parameters**: `question` (your query), `image_url` (optional)
 
+- `/agentic_query`: Ask a question using tool-powered search (initial 5 chunks; tools retrieve up to 5 each)
+  - **Parameters**: `question` (your query)
+
 - `/query_full_context`: Ask a question using ALL documents as context (1/day limit)
   - **Parameters**: `question` (your query)
   - Uses powerful models like Gemini 2.5 Pro for comprehensive analysis.

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -452,7 +452,7 @@ The bot will display a startup banner and initialize all components.
 - `/query`: Ask a question with optional image
   - **Parameters**: `question` (your query), `image_url` (optional)
 
-- `/agentic_query`: Ask a question using tool-powered search (initial 5 chunks; tools retrieve up to 5 each)
+- `/agentic_query`: Ask a question using tool-powered search (initial 5 chunks; tools retrieve up to 5 each and can view specific chunks)
   - **Parameters**: `question` (your query)
 
 - `/query_full_context`: Ask a question using ALL documents as context (1/day limit)

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -436,7 +436,7 @@ The bot will display a startup banner and initialize all components.
 - `/query`: Ask a question with optional image
   - **Parameters**: `question` (your query), `image_url` (optional)
 
-- `/agentic_query`: Ask a question using tool-powered search (initial 5 chunks; tools retrieve up to 5 each)
+- `/agentic_query`: Ask a question using tool-powered search (initial 5 chunks; tools retrieve up to 5 each and can view specific chunks)
   - **Parameters**: `question` (your query)
 
 - `/query_full_context`: Ask a question using ALL documents as context (1/day limit)

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -436,6 +436,9 @@ The bot will display a startup banner and initialize all components.
 - `/query`: Ask a question with optional image
   - **Parameters**: `question` (your query), `image_url` (optional)
 
+- `/agentic_query`: Ask a question using tool-powered search (initial 5 chunks; tools retrieve up to 5 each)
+  - **Parameters**: `question` (your query)
+
 - `/query_full_context`: Ask a question using ALL documents as context (1/day limit)
   - **Parameters**: `question` (your query)
   - Uses powerful models like Gemini 2.5 Pro for comprehensive analysis.


### PR DESCRIPTION
## Summary
- introduce agentic query command letting the model call search tools
- expose keyword, BM25, and hybrid search functions as OpenRouter tools
- document new agentic query capability
- skip short-response warning when a model returns tool calls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689255e9f8408326a6112427f0bcdb0a