### PR TITLE
Avoid retries for empty agentic responses

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2857,7 +2857,10 @@ class DiscordBot(commands.Bot):
         for iteration in range(max_iterations):
             logger.info("Agentic loop iteration %s", iteration + 1)
             completion, _ = await self._try_ai_completion(
-                model, messages, tools=tools
+                model,
+                messages,
+                tools=tools,
+                min_response_length=0,
             )
             if not completion or not completion.get("choices"):
                 return "*neural error detected!*"


### PR DESCRIPTION
## Summary
- Skip minimum response length check in agentic_query, preventing unnecessary retries when models return empty content.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68929947cf7c83268df213ae72960dee