### PR TITLE
Allow view_chunks to resolve document identifiers

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2658,11 +2658,11 @@ class DiscordBot(commands.Bot):
 
     async def _tool_view_chunks(
         self,
-        doc_uuid: str,
+        document: str,
         chunk_indices: List[int],
         contextualized: bool = False,
     ) -> List[Dict[str, Any]]:
-        """Tool: Retrieve specific chunks from a document by UUID."""
+        """Tool: Retrieve specific chunks from a document by identifier."""
         if not chunk_indices:
             return []
 
@@ -2671,8 +2671,22 @@ class DiscordBot(commands.Bot):
                 "view_chunks requested %s indices; clamped to 5", len(chunk_indices)
             )
         indices = [int(i) for i in chunk_indices[:5]]
+
+        doc_uuid = self.document_manager.resolve_doc_uuid(document)
+        if not doc_uuid:
+            logger.warning("view_chunks document %s not found", document)
+            return [
+                {
+                    "chunk_index": int(idx),
+                    "total_chunks": 0,
+                    "content": "Document not found",
+                }
+                for idx in indices
+            ]
+
         logger.info(
-            "view_chunks tool invoked for %s with indices %s (contextualized=%s)",
+            "view_chunks tool invoked for %s (resolved to %s) with indices %s (contextualized=%s)",
+            document,
             doc_uuid,
             indices,
             contextualized,
@@ -2793,11 +2807,11 @@ class DiscordBot(commands.Bot):
                 "type": "function",
                 "function": {
                     "name": "view_chunks",
-                    "description": "Retrieve specific chunks from a document by UUID.",
+                    "description": "Retrieve specific chunks from a document by identifier (UUID, name, or Google Doc ID).",
                     "parameters": {
                         "type": "object",
                         "properties": {
-                            "doc_uuid": {"type": "string"},
+                            "document": {"type": "string", "description": "UUID, document name, or Google Doc ID"},
                             "chunk_indices": {
                                 "type": "array",
                                 "items": {"type": "integer"},
@@ -2808,7 +2822,7 @@ class DiscordBot(commands.Bot):
                                 "default": False,
                             },
                         },
-                        "required": ["doc_uuid", "chunk_indices"],
+                        "required": ["document", "chunk_indices"],
                     },
                 },
             },

--- a/tests/test_document_manager.py
+++ b/tests/test_document_manager.py
@@ -2,6 +2,10 @@ import importlib.util
 from pathlib import Path
 import sys
 import types
+import importlib.util
+import json
+import pytest
+import asyncio
 
 
 def load_document_module():
@@ -13,9 +17,17 @@ def load_document_module():
         def configure(api_key=None):
             pass
         genai_mod.configure = configure
+        types_mod = types.ModuleType('google.generativeai.types')
+        class HarmCategory:
+            pass
+        class HarmBlockThreshold:
+            pass
+        types_mod.HarmCategory = HarmCategory
+        types_mod.HarmBlockThreshold = HarmBlockThreshold
         google_pkg.generativeai = genai_mod
         sys.modules['google'] = google_pkg
         sys.modules['google.generativeai'] = genai_mod
+        sys.modules['google.generativeai.types'] = types_mod
     if 'numpy' not in sys.modules:
         numpy_dummy = types.ModuleType('numpy')
         numpy_dummy.ndarray = object
@@ -48,9 +60,21 @@ def load_document_module():
         def sanitize_for_logging(message):
             return message
         logging_pkg.sanitize_for_logging = sanitize_for_logging
+        helpers_pkg = types.ModuleType('utils.helpers')
+        def dummy(*args, **kwargs):
+            return None
+        logging_pkg.log_qa_pair = dummy
+        helpers_pkg.check_permissions = dummy
+        helpers_pkg.is_image = lambda *a, **kw: False
+        helpers_pkg.split_message = lambda msg, limit=2000: [msg]
+        helpers_pkg.sanitize_filename = lambda name: name
+        helpers_pkg.xml_wrap = lambda tag, content: f"<{tag}>{content}</{tag}>"
+        helpers_pkg.wrap_document = lambda content, source, metadata="": content
         utils_pkg.logging = logging_pkg
+        utils_pkg.helpers = helpers_pkg
         sys.modules['utils'] = utils_pkg
         sys.modules['utils.logging'] = logging_pkg
+        sys.modules['utils.helpers'] = helpers_pkg
     if 'dotenv' not in sys.modules:
         dotenv_dummy = types.ModuleType('dotenv')
         def load_dotenv():
@@ -71,6 +95,102 @@ def load_document_module():
     if str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
     spec = importlib.util.spec_from_file_location("documents", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_bot_module():
+    module_path = Path(__file__).resolve().parents[1] / "bot.py"
+
+    # Ensure discord stubs with required attributes
+    if 'discord' not in sys.modules:
+        discord_mod = types.ModuleType('discord')
+        sys.modules['discord'] = discord_mod
+    else:
+        discord_mod = sys.modules['discord']
+    class Intents:
+        def __init__(self):
+            self.message_content = False
+
+        @staticmethod
+        def default():
+            return Intents()
+    discord_mod.Intents = Intents
+    discord_mod.Interaction = getattr(discord_mod, 'Interaction', object)
+    # Basic discord classes used in type hints
+    class _Empty:
+        pass
+    discord_mod.TextChannel = _Empty
+    discord_mod.Message = _Empty
+    discord_mod.Member = _Empty
+    app_cmds = types.ModuleType('discord.app_commands')
+    class DummyCheckFailure(Exception):
+        pass
+    app_cmds.CheckFailure = DummyCheckFailure
+    discord_mod.app_commands = app_cmds
+    ext_module = types.ModuleType('discord.ext')
+    commands_module = types.ModuleType('discord.ext.commands')
+    class DummyBot:
+        def __init__(self, *args, **kwargs):
+            pass
+    commands_module.Bot = DummyBot
+    class Context:
+        pass
+    commands_module.Context = Context
+    tasks_module = types.ModuleType('discord.ext.tasks')
+    def loop(*args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+    tasks_module.loop = loop
+    ext_module.commands = commands_module
+    ext_module.tasks = tasks_module
+    discord_mod.ext = ext_module
+    sys.modules['discord.app_commands'] = app_cmds
+    sys.modules['discord.ext'] = ext_module
+    sys.modules['discord.ext.commands'] = commands_module
+    sys.modules['discord.ext.tasks'] = tasks_module
+
+    # Stub commands package to avoid heavy imports
+    if 'commands' not in sys.modules:
+        commands_pkg = types.ModuleType('commands')
+        for name in [
+            'document_commands',
+            'image_commands',
+            'conversation_commands',
+            'admin_commands',
+            'utility_commands',
+            'query_commands',
+            'tracking_commands',
+        ]:
+            sub = types.ModuleType(f'commands.{name}')
+            setattr(commands_pkg, name, sub)
+            sys.modules[f'commands.{name}'] = sub
+        sys.modules['commands'] = commands_pkg
+
+    # Stub apscheduler
+    if 'apscheduler.schedulers.asyncio' not in sys.modules:
+        apscheduler_pkg = types.ModuleType('apscheduler')
+        schedulers_pkg = types.ModuleType('apscheduler.schedulers')
+        asyncio_pkg = types.ModuleType('apscheduler.schedulers.asyncio')
+        class DummyScheduler:
+            def add_job(self, *a, **kw):
+                pass
+
+            def start(self):
+                pass
+        asyncio_pkg.AsyncIOScheduler = DummyScheduler
+        schedulers_pkg.asyncio = asyncio_pkg
+        apscheduler_pkg.schedulers = schedulers_pkg
+        sys.modules['apscheduler'] = apscheduler_pkg
+        sys.modules['apscheduler.schedulers'] = schedulers_pkg
+        sys.modules['apscheduler.schedulers.asyncio'] = asyncio_pkg
+
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    spec = importlib.util.spec_from_file_location("bot", module_path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -123,3 +243,36 @@ def test_search_keyword_bm25(tmp_path):
     assert name == "TestDoc"
     assert index == 1 and total == 2
     assert "airship" in chunk.lower()
+
+
+def test_view_chunks_accepts_identifiers(tmp_path):
+    bot_mod = load_bot_module()
+    manager = DocumentManager(base_dir=str(tmp_path), config=DummyConfig())
+    manager.chunks = {"uuid-123": ["First chunk", "Second"]}
+    manager.contextualized_chunks = {"uuid-123": ["Ctx first", "Ctx second"]}
+    manager.metadata = {"uuid-123": {"original_name": "MyDoc"}}
+    tracked = [
+        {
+            "google_doc_id": "gdoc123",
+            "internal_doc_uuid": "uuid-123",
+            "original_name_at_import": "MyDoc",
+        }
+    ]
+    (Path(tmp_path) / "tracked_google_docs.json").write_text(json.dumps(tracked))
+
+    dummy_bot = types.SimpleNamespace(
+        document_manager=manager,
+        config=types.SimpleNamespace(USE_CONTEXTUALISED_CHUNKS=True),
+    )
+
+    res_uuid = asyncio.run(bot_mod.DiscordBot._tool_view_chunks(dummy_bot, "uuid-123", [1]))
+    res_name = asyncio.run(bot_mod.DiscordBot._tool_view_chunks(dummy_bot, "MyDoc", [1]))
+    res_gdoc = asyncio.run(bot_mod.DiscordBot._tool_view_chunks(dummy_bot, "gdoc123", [1]))
+    res_gdoc_url = asyncio.run(
+        bot_mod.DiscordBot._tool_view_chunks(
+            dummy_bot, "https://docs.google.com/document/d/gdoc123/edit", [1]
+        )
+    )
+
+    assert res_uuid == res_name == res_gdoc == res_gdoc_url
+    assert res_uuid[0]["content"] == "First chunk"


### PR DESCRIPTION
## Summary
- Enable `view_chunks` to accept document UUIDs, names, or Google Doc IDs by resolving identifiers in `DocumentManager`
- Update tool schema to use generic `document` parameter and resolve identifier before fetching chunks
- Add tests ensuring `view_chunks` works with names and Google Doc IDs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68929c25fa6c8326971896ef55277e07