### PR TITLE
Make agentic query model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ GOOGLE_API_KEY=your_google_api_key
 LLM_MODEL=google/gemini-2.5-flash # Default model for text generation
 DEFAULT_MODEL=qwen/qwq-32b # Default user preference model
 CLASSIFIER_MODEL=google/gemini-2.5-flash # Model for classification tasks
+AGENTIC_MODEL=openai/o4-mini # Primary model for agentic queries; fallbacks: o4-mini, gpt-oss-120b
 EMBEDDING_MODEL=models/text-embedding-004 # Model for document embeddings
 EMBEDDING_DIMENSIONS=0 # Set to positive number to truncate embeddings (0 = no truncation)
 

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -575,8 +575,9 @@ def register_commands(bot):
                 question,
             )
 
-            # Always use o4-mini for agentic queries with gpt-oss-120b as fallback
-            model_list = ["openai/o4-mini", "openai/gpt-oss-120b"]
+            # Use configured agentic model with fallbacks to o4-mini and gpt-oss-120b
+            model_list = [bot.config.AGENTIC_MODEL, "openai/o4-mini", "openai/gpt-oss-120b"]
+            model_list = list(dict.fromkeys(model_list))
             logger.debug(
                 "Using model list %s for agentic query from user %s",
                 model_list,

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -269,6 +269,7 @@ GOOGLE_API_KEY=your_google_api_key
 LLM_MODEL=google/gemini-2.5-flash # Default model for text generation
 DEFAULT_MODEL=qwen/qwq-32b # Default user preference model
 CLASSIFIER_MODEL=google/gemini-2.5-flash # Model for classification tasks
+AGENTIC_MODEL=openai/o4-mini # Primary model for agentic queries; fallbacks: o4-mini, gpt-oss-120b
 EMBEDDING_MODEL=models/text-embedding-004 # Model for document embeddings
 EMBEDDING_DIMENSIONS=0 # Set to positive number to truncate embeddings (0 = no truncation)
 

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -260,6 +260,7 @@ GOOGLE_API_KEY=your_google_api_key
 LLM_MODEL=google/gemini-2.5-flash # Default model for text generation
 DEFAULT_MODEL=qwen/qwq-32b # Default user preference model
 CLASSIFIER_MODEL=google/gemini-2.5-flash # Model for classification tasks
+AGENTIC_MODEL=openai/o4-mini # Primary model for agentic queries; fallbacks: o4-mini, gpt-oss-120b
 EMBEDDING_MODEL=models/text-embedding-004 # Model for document embeddings
 EMBEDDING_DIMENSIONS=0 # Set to positive number to truncate embeddings (0 = no truncation)
 

--- a/managers/config.py
+++ b/managers/config.py
@@ -21,6 +21,7 @@ class Config:
         self.LLM_MODEL = os.getenv('LLM_MODEL', 'google/gemini-2.5-flash')
         self.DEFAULT_MODEL = os.getenv('DEFAULT_MODEL', 'qwen/qwq-32b')
         self.CLASSIFIER_MODEL = os.getenv('CLASSIFIER_MODEL', 'google/gemini-2.5-flash')
+        self.AGENTIC_MODEL = os.getenv('AGENTIC_MODEL', 'openai/o4-mini')
         
         # New embedding configuration
         self.EMBEDDING_MODEL = os.getenv('EMBEDDING_MODEL', 'models/text-embedding-004')


### PR DESCRIPTION
## Summary
- allow default agentic query model to be set via `AGENTIC_MODEL` env var
- agentic queries now fall back to `openai/o4-mini` and `openai/gpt-oss-120b`
- document new env var in README and docs

## Testing
- `DISCORD_BOT_TOKEN=dummy OPENROUTER_API_KEY=dummy GOOGLE_API_KEY=dummy pytest`

------
https://chatgpt.com/codex/tasks/task_e_68929f38f7708326961affcf714341a1