### PR TITLE
Add progress updates for agentic queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Comprehensive tools to help troubleshoot issues:
 | Command | Description |
 |---------|-------------|
 | `/query` | Ask a question with optional image URL |
-| `/agentic_query` | Ask a question using tool-powered search (starts with 5 chunks; tools fetch up to 5 each and can retrieve specific chunks) |
+| `/agentic_query` | Ask a question using tool-powered search with progress updates (starts with 5 chunks; tools fetch up to 5 each and can retrieve specific chunks) |
 | `/history` | View your conversation history |
 | `/manage_history` | View and manage history with indices |
 | `/delete_history_messages` | Delete specific messages |

--- a/bot.py
+++ b/bot.py
@@ -21,7 +21,7 @@ import numpy as np
 from datetime import datetime
 from textwrap import shorten
 from pathlib import Path
-from typing import List, Dict, Tuple, Optional, Any, Set, Union # Added Union
+from typing import List, Dict, Tuple, Optional, Any, Set, Union, Callable, Awaitable # Added Union
 from discord import app_commands
 from discord.ext import commands
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -2751,7 +2751,12 @@ class DiscordBot(commands.Bot):
         summary = await self.document_manager.get_document_summary(document)
         return summary if summary is not None else "Document not found"
 
-    async def agentic_query(self, question: str, model: Union[str, List[str]]) -> Tuple[str, Optional[str]]:
+    async def agentic_query(
+        self,
+        question: str,
+        model: Union[str, List[str]],
+        progress_callback: Optional[Callable[[str], Awaitable[None]]] = None,
+    ) -> Tuple[str, Optional[str]]:
         """Answer a question by letting the model call search tools agentically.
 
         Args:
@@ -2919,6 +2924,27 @@ class DiscordBot(commands.Bot):
 
         max_iterations = 30
         actual_model = None
+
+        def describe_tool(name: str, args: Dict[str, Any]) -> str:
+            if name == "list_documents":
+                return "Listing all documents"
+            if name == "search_keyword":
+                return f"Searching for keyword '{args.get('keyword')}'"
+            if name == "search_keyword_bm25":
+                return f"Searching for keyword '{args.get('keyword')}' with BM25"
+            if name == "search_documents":
+                return f"Searching documents for query '{args.get('query')}'"
+            if name == "view_chunks":
+                return f"Viewing chunks {args.get('chunk_indices')} from document '{args.get('document')}'"
+            if name == "get_document_summary":
+                return f"Getting summary for document '{args.get('document')}'"
+            return f"Using tool {name}"
+
+        def summarize_tool(name: str, result: Any) -> str:
+            if isinstance(result, list):
+                return f"Tool {name} returned {len(result)} result(s)"
+            return f"Tool {name} completed"
+
         for iteration in range(max_iterations):
             logger.info("Agentic loop iteration %s", iteration + 1)
 
@@ -2940,12 +2966,22 @@ class DiscordBot(commands.Bot):
                 for call in tool_calls:
                     name = call["function"]["name"]
                     args = json.loads(call["function"].get("arguments", "{}"))
+                    if progress_callback:
+                        try:
+                            await progress_callback(describe_tool(name, args))
+                        except Exception as e:
+                            logger.warning("Progress callback failed: %s", e)
                     logger.debug("Executing tool %s with args %s", name, args)
                     func = tool_mapping.get(name)
                     if func:
                         result = await func(**args)
                     else:
                         result = {"error": f"Unknown tool {name}"}
+                    if progress_callback:
+                        try:
+                            await progress_callback(summarize_tool(name, result))
+                        except Exception as e:
+                            logger.warning("Progress callback failed: %s", e)
                     logger.debug(
                         "Tool %s returned %s item(s)",
                         name,

--- a/bot.py
+++ b/bot.py
@@ -2927,23 +2927,25 @@ class DiscordBot(commands.Bot):
 
         def describe_tool(name: str, args: Dict[str, Any]) -> str:
             if name == "list_documents":
-                return "Listing all documents"
+                return "*cataloguing Imperial archives...*"
             if name == "search_keyword":
-                return f"Searching for keyword '{args.get('keyword')}'"
+                return f"*neural mesh hums: scanning for '{args.get('keyword')}'...*"
             if name == "search_keyword_bm25":
-                return f"Searching for keyword '{args.get('keyword')}' with BM25"
+                return f"*BM25 heuristics spin up—hunting '{args.get('keyword')}' among the data spires...*"
             if name == "search_documents":
-                return f"Searching documents for query '{args.get('query')}'"
+                return f"*cross-referencing '{args.get('query')}' with memory banks...*"
             if name == "view_chunks":
-                return f"Viewing chunks {args.get('chunk_indices')} from document '{args.get('document')}'"
+                return (
+                    f"*retrieving chunk(s) {args.get('chunk_indices')} from '{args.get('document')}'...*"
+                )
             if name == "get_document_summary":
-                return f"Getting summary for document '{args.get('document')}'"
-            return f"Using tool {name}"
+                return f"*summoning abridged chronicle of '{args.get('document')}'...*"
+            return f"*invoking tool {name}...*"
 
         def summarize_tool(name: str, result: Any) -> str:
             if isinstance(result, list):
-                return f"Tool {name} returned {len(result)} result(s)"
-            return f"Tool {name} completed"
+                return f"*{name} yielded {len(result)} fragment(s).*"
+            return f"*{name} completed.*"
 
         for iteration in range(max_iterations):
             logger.info("Agentic loop iteration %s", iteration + 1)

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -585,12 +585,14 @@ def register_commands(bot):
             )
 
             status_message = await interaction.followup.send("*neural pathways activating...*", ephemeral=False)
+            progress_lines = ["*neural pathways activating...*"]
 
             async def progress_update(msg: str) -> None:
                 try:
-                    await interaction.followup.send(msg, ephemeral=False)
+                    progress_lines.append(msg)
+                    await status_message.edit(content="\n".join(progress_lines))
                 except Exception as e:
-                    logger.error(f"Failed to send progress update: {e}")
+                    logger.error(f"Failed to update progress message: {e}")
 
             response, actual_model = await bot.agentic_query(
                 question, model_list, progress_callback=progress_update

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -586,7 +586,15 @@ def register_commands(bot):
 
             status_message = await interaction.followup.send("*neural pathways activating...*", ephemeral=False)
 
-            response, actual_model = await bot.agentic_query(question, model_list)
+            async def progress_update(msg: str) -> None:
+                try:
+                    await interaction.followup.send(msg, ephemeral=False)
+                except Exception as e:
+                    logger.error(f"Failed to send progress update: {e}")
+
+            response, actual_model = await bot.agentic_query(
+                question, model_list, progress_callback=progress_update
+            )
             logger.debug(
                 "Agentic query response length: %s characters",
                 len(response) if response else 0,

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -584,12 +584,17 @@ def register_commands(bot):
                 interaction.user.id,
             )
 
-            status_message = await interaction.followup.send("*neural pathways activating...*", ephemeral=False)
-            progress_lines = ["*neural pathways activating...*"]
+            status_message = await interaction.followup.send(
+                "*neural pathways activating... calibrating search heuristics...*",
+                ephemeral=False,
+            )
+            progress_lines = [
+                "*neural pathways activating... calibrating search heuristics...*"
+            ]
 
             async def progress_update(msg: str) -> None:
                 try:
-                    progress_lines.append(msg)
+                    progress_lines.append(f"➤ {msg}")
                     await status_message.edit(content="\n".join(progress_lines))
                 except Exception as e:
                     logger.error(f"Failed to update progress message: {e}")

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -453,7 +453,7 @@ The bot will display a startup banner and initialize all components.
 - `/query`: Ask a question with optional image
   - **Parameters**: `question` (your query), `image_url` (optional)
 
-- `/agentic_query`: Ask a question using tool-powered search (initial 5 chunks; tools retrieve up to 5 each and can view specific chunks)
+- `/agentic_query`: Ask a question using tool-powered search with progress updates (initial 5 chunks; tools retrieve up to 5 each and can view specific chunks)
   - **Parameters**: `question` (your query)
 
 - `/query_full_context`: Ask a question using ALL documents as context (1/day limit)

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -437,7 +437,7 @@ The bot will display a startup banner and initialize all components.
 - `/query`: Ask a question with optional image
   - **Parameters**: `question` (your query), `image_url` (optional)
 
-- `/agentic_query`: Ask a question using tool-powered search (initial 5 chunks; tools retrieve up to 5 each and can view specific chunks)
+- `/agentic_query`: Ask a question using tool-powered search with progress updates (initial 5 chunks; tools retrieve up to 5 each and can view specific chunks)
   - **Parameters**: `question` (your query)
 
 - `/query_full_context`: Ask a question using ALL documents as context (1/day limit)


### PR DESCRIPTION
## Summary
- Allow `agentic_query` to report tool usage and results via an optional progress callback
- Send progress updates to Discord users during `/agentic_query` execution
- Document that `/agentic_query` now provides progress updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892b094af4883268205a0553e9fc548