### PR TITLE
Allow agentic_query tools to set top_k

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Comprehensive tools to help troubleshoot issues:
 | Command | Description |
 |---------|-------------|
 | `/query` | Ask a question with optional image URL |
-| `/agentic_query` | Ask a question using tool-powered search with progress updates (starts with 5 chunks; tools fetch up to 5 each and can retrieve specific chunks) |
+| `/agentic_query` | Ask a question using tool-powered search with progress updates (starts with 5 chunks; tools fetch up to the requested number of chunks—default 5, max 20—and can retrieve specific chunks) |
 | `/history` | View your conversation history |
 | `/manage_history` | View and manage history with indices |
 | `/delete_history_messages` | Delete specific messages |

--- a/bot.py
+++ b/bot.py
@@ -2575,10 +2575,13 @@ class DiscordBot(commands.Bot):
             raise TypeError("keyword (or query) must be provided")
 
         requested_k = top_k
-        top_k = min(top_k, 5)
-        if requested_k > 5:
+        max_results = getattr(self.config, "MAX_TOP_K", 20)
+        top_k = min(top_k, max_results)
+        if requested_k > max_results:
             logger.debug(
-                "search_keyword requested top_k=%s; clamped to %s", requested_k, top_k
+                "search_keyword requested top_k=%s; clamped to %s",
+                requested_k,
+                top_k,
             )
         logger.info("search_keyword tool invoked for '%s' with top_k=%s", keyword, top_k)
         results = self.document_manager.search_keyword(keyword, top_k=top_k)
@@ -2611,10 +2614,13 @@ class DiscordBot(commands.Bot):
             raise TypeError("keyword (or query) must be provided")
 
         requested_k = top_k
-        top_k = min(top_k, 5)
-        if requested_k > 5:
+        max_results = getattr(self.config, "MAX_TOP_K", 20)
+        top_k = min(top_k, max_results)
+        if requested_k > max_results:
             logger.debug(
-                "search_keyword_bm25 requested top_k=%s; clamped to %s", requested_k, top_k
+                "search_keyword_bm25 requested top_k=%s; clamped to %s",
+                requested_k,
+                top_k,
             )
         logger.info(
             "search_keyword_bm25 tool invoked for '%s' with top_k=%s", keyword, top_k
@@ -2635,10 +2641,13 @@ class DiscordBot(commands.Bot):
     async def _tool_search_documents(self, query: str, top_k: int = 5) -> List[Dict[str, Any]]:
         """Tool: Hybrid embedding/BM25 search across documents."""
         requested_k = top_k
-        top_k = min(top_k, 5)
-        if requested_k > 5:
+        max_results = getattr(self.config, "MAX_TOP_K", 20)
+        top_k = min(top_k, max_results)
+        if requested_k > max_results:
             logger.debug(
-                "search_documents requested top_k=%s; clamped to %s", requested_k, top_k
+                "search_documents requested top_k=%s; clamped to %s",
+                requested_k,
+                top_k,
             )
         logger.info("search_documents tool invoked for '%s' with top_k=%s", query, top_k)
         results = await self.document_manager.search(query, top_k=top_k)
@@ -2780,6 +2789,7 @@ class DiscordBot(commands.Bot):
         )
 
         document_list_content = self.document_manager.get_document_list_content()
+        max_results = getattr(self.config, "MAX_TOP_K", 20)
 
         tools = [
             {
@@ -2802,7 +2812,11 @@ class DiscordBot(commands.Bot):
                         "type": "object",
                         "properties": {
                             "keyword": {"type": "string"},
-                            "top_k": {"type": "integer", "default": 5},
+                            "top_k": {
+                                "type": "integer",
+                                "default": 5,
+                                "description": f"Number of results to return (max {max_results})",
+                            },
                         },
                         "required": ["keyword"],
                     },
@@ -2817,7 +2831,11 @@ class DiscordBot(commands.Bot):
                         "type": "object",
                         "properties": {
                             "keyword": {"type": "string"},
-                            "top_k": {"type": "integer", "default": 5},
+                            "top_k": {
+                                "type": "integer",
+                                "default": 5,
+                                "description": f"Number of results to return (max {max_results})",
+                            },
                         },
                         "required": ["keyword"],
                     },
@@ -2832,7 +2850,11 @@ class DiscordBot(commands.Bot):
                         "type": "object",
                         "properties": {
                             "query": {"type": "string"},
-                            "top_k": {"type": "integer", "default": 5},
+                            "top_k": {
+                                "type": "integer",
+                                "default": 5,
+                                "description": f"Number of results to return (max {max_results})",
+                            },
                         },
                         "required": ["query"],
                     },
@@ -2914,7 +2936,7 @@ class DiscordBot(commands.Bot):
                     "Only the above 5 chunks were retrieved initially. "
                     "If you need more information, use the available search tools "
                     "(search_keyword, search_keyword_bm25, search_documents, view_chunks). "
-                    "Each tool returns at most 5 chunks."
+                    f"Each tool returns up to the number of chunks you request (default 5, maximum {max_results})."
                     "Be comprehensive in your searching so that your final answer is as accurate as possible."
                     "Do not output tables or other complex formats, just text and markdown that can be outputted in Discord."
                 ),

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -453,7 +453,7 @@ The bot will display a startup banner and initialize all components.
 - `/query`: Ask a question with optional image
   - **Parameters**: `question` (your query), `image_url` (optional)
 
-- `/agentic_query`: Ask a question using tool-powered search with progress updates (initial 5 chunks; tools retrieve up to 5 each and can view specific chunks)
+- `/agentic_query`: Ask a question using tool-powered search with progress updates (initial 5 chunks; tools retrieve up to the requested number of chunks—default 5, max 20—and can view specific chunks)
   - **Parameters**: `question` (your query)
 
 - `/query_full_context`: Ask a question using ALL documents as context (1/day limit)

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -437,7 +437,7 @@ The bot will display a startup banner and initialize all components.
 - `/query`: Ask a question with optional image
   - **Parameters**: `question` (your query), `image_url` (optional)
 
-- `/agentic_query`: Ask a question using tool-powered search with progress updates (initial 5 chunks; tools retrieve up to 5 each and can view specific chunks)
+- `/agentic_query`: Ask a question using tool-powered search with progress updates (initial 5 chunks; tools retrieve up to the requested number of chunks—default 5, max 20—and can view specific chunks)
   - **Parameters**: `question` (your query)
 
 - `/query_full_context`: Ask a question using ALL documents as context (1/day limit)


### PR DESCRIPTION
## Summary
- Let agentic query search tools clamp requested `top_k` against config `MAX_TOP_K`
- Document maximum result count in tool schemas and system instructions
- Update README and docs to note adjustable `top_k`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892ba15b6808326828f30c864478d9b