### PR TITLE
feat: make view chunk limit configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ TOP_K=5 # Base number of search results
 MAX_TOP_K=20 # Maximum search results
 TOP_K_MULTIPLIER=1.0 # Multiplier for TOP_K
 BM25_WEIGHT=0.25 # Weight for BM25 vs embedding search (0.25 = 25% BM25, 75% embedding)
+VIEW_CHUNK_LIMIT=5 # Maximum chunks returned by view_chunks tool
 
 # API settings
 API_TIMEOUT=180 # Seconds

--- a/bot.py
+++ b/bot.py
@@ -2687,12 +2687,14 @@ class DiscordBot(commands.Bot):
         """Tool: Retrieve specific chunks from a document by identifier."""
         if not chunk_indices:
             return []
-
-        if len(chunk_indices) > 5:
+        view_chunk_limit = getattr(self.config, "VIEW_CHUNK_LIMIT", 5)
+        if len(chunk_indices) > view_chunk_limit:
             logger.debug(
-                "view_chunks requested %s indices; clamped to 5", len(chunk_indices)
+                "view_chunks requested %s indices; clamped to %s",
+                len(chunk_indices),
+                view_chunk_limit,
             )
-        indices = [int(i) for i in chunk_indices[:5]]
+        indices = [int(i) for i in chunk_indices[:view_chunk_limit]]
 
         doc_uuid = self.document_manager.resolve_doc_uuid(document)
         if not doc_uuid:
@@ -2803,6 +2805,7 @@ class DiscordBot(commands.Bot):
 
         document_list_content = self.document_manager.get_document_list_content()
         max_results = getattr(self.config, "MAX_TOP_K", 20)
+        view_chunk_limit = getattr(self.config, "VIEW_CHUNK_LIMIT", 5)
 
         tools = [
             {
@@ -2888,7 +2891,8 @@ class DiscordBot(commands.Bot):
                     "name": "view_chunks",
                     "description": (
                         "Retrieve the text of specific chunks from a document by identifier "
-                        "(UUID, name, or Google Doc ID)."
+                        "(UUID, name, or Google Doc ID). "
+                        f"Returns up to {view_chunk_limit} chunks per call."
                     ),
                     "parameters": {
                         "type": "object",
@@ -2962,7 +2966,8 @@ class DiscordBot(commands.Bot):
                     "If you need more information, use the available search tools "
                     "(search_keyword, search_keyword_bm25, search_documents, view_chunks). "
                     "Search tools return chunk references without their text; use view_chunks to read them. "
-                    f"Each tool returns up to the number of chunks you request (default 5, maximum {max_results})."
+                    f"Each search tool returns up to the number of chunks you request (default 5, maximum {max_results}). "
+                    f"The view_chunks tool can return up to {view_chunk_limit} chunks at a time. "
                     "Be comprehensive in your searching so that your final answer is as accurate and complete as possible. "
                     "Be sure to check the region documents for information pertaining to natives. "
                     "Do not output tables or other complex formats, just text and markdown that can be outputted in Discord. "

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -282,6 +282,7 @@ TOP_K=5 # Base number of search results
 MAX_TOP_K=20 # Maximum search results
 TOP_K_MULTIPLIER=1.0 # Multiplier for TOP_K
 BM25_WEIGHT=0.25 # Weight for BM25 vs embedding search (0.25 = 25% BM25, 75% embedding)
+VIEW_CHUNK_LIMIT=5 # Maximum chunks returned by view_chunks tool
 
 # API settings
 API_TIMEOUT=180 # Seconds

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -273,6 +273,7 @@ TOP_K=5 # Base number of search results
 MAX_TOP_K=20 # Maximum search results
 TOP_K_MULTIPLIER=1.0 # Multiplier for TOP_K
 BM25_WEIGHT=0.25 # Weight for BM25 vs embedding search (0.25 = 25% BM25, 75% embedding)
+VIEW_CHUNK_LIMIT=5 # Maximum chunks returned by view_chunks tool
 
 # API settings
 API_TIMEOUT=180 # Seconds

--- a/managers/config.py
+++ b/managers/config.py
@@ -34,6 +34,7 @@ class Config:
         # TOP_K configuration with multiplier
         self.TOP_K = int(os.getenv('TOP_K', '5'))
         self.MAX_TOP_K = int(os.getenv('MAX_TOP_K', '20'))
+        self.VIEW_CHUNK_LIMIT = int(os.getenv('VIEW_CHUNK_LIMIT', '5'))
         self.TOP_K_MULTIPLIER = float(os.getenv('TOP_K_MULTIPLIER', '1'))  # Default to no change
 
         self.MODEL_TOP_K = {

--- a/tests/test_document_manager.py
+++ b/tests/test_document_manager.py
@@ -278,6 +278,22 @@ def test_view_chunks_accepts_identifiers(tmp_path):
     assert res_uuid[0]["content"] == "First chunk"
 
 
+def test_view_chunks_respects_limit(tmp_path):
+    bot_mod = load_bot_module()
+    manager = DocumentManager(base_dir=str(tmp_path), config=DummyConfig())
+    manager.chunks = {"doc": ["A", "B", "C"]}
+    manager.metadata = {"doc": {"original_name": "Doc"}}
+
+    dummy_bot = types.SimpleNamespace(
+        document_manager=manager,
+        config=types.SimpleNamespace(USE_CONTEXTUALISED_CHUNKS=True, VIEW_CHUNK_LIMIT=2),
+    )
+
+    res = asyncio.run(bot_mod.DiscordBot._tool_view_chunks(dummy_bot, "doc", [1, 2, 3]))
+    assert len(res) == 2
+    assert [c["chunk_index"] for c in res] == [1, 2]
+
+
 def test_get_document_summary_existing(tmp_path):
     manager = DocumentManager(base_dir=str(tmp_path), config=DummyConfig())
     manager.metadata = {"abc": {"original_name": "Doc", "summary": "Existing"}}


### PR DESCRIPTION
## Summary
- allow `view_chunks` clamp to be set via `VIEW_CHUNK_LIMIT` env variable
- expose configurable limit in agentic-query tool descriptions
- document `VIEW_CHUNK_LIMIT` and test chunk clamp behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892c49d00988326b6bbdb8b07ad983b