### PR TITLE
Enable reasoning for all OpenRouter queries

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -234,7 +234,8 @@ class DiscordBot(commands.Bot):
             payload = {
                 "model": "google/gemini-2.5-flash:thinking",  # Use a vision-capable model
                 "messages": messages,
-                "temperature": 0.1
+                "temperature": 0.1,
+                "reasoning": {"enabled": True},
             }
             
             async with aiohttp.ClientSession() as session:
@@ -1535,6 +1536,8 @@ class DiscordBot(commands.Bot):
                         "max_tokens": 20000,
                         **kwargs,
                     }
+                    if "reasoning" not in payload:
+                        payload["reasoning"] = {"enabled": True}
 
                     if provider_config:
                         payload["provider"] = provider_config

--- a/cli.py
+++ b/cli.py
@@ -153,6 +153,7 @@ async def _cli_try_ai_completion(
                 "temperature": temperature,
                 "max_tokens": 8000,  # Keep max tokens high
             }
+            payload["reasoning"] = {"enabled": True}
 
             provider_config = provider_base
             if provider_choice:

--- a/managers/documents.py
+++ b/managers/documents.py
@@ -342,6 +342,7 @@ class DocumentManager:
             
             for model in fallback_models:
                 payload = {"model": model, "messages": messages, "temperature": 0.2, "max_tokens": 200}
+                payload["reasoning"] = {"enabled": True}
                 for _ in range(2):  # Retry once per model
                     try:
                         async with aiohttp.ClientSession() as session:
@@ -651,7 +652,8 @@ class DocumentManager:
             fallback_models = ["google/gemini-2.5-flash-lite-preview-06-17", "amazon/nova-lite-v1", "google/gemini-2.0-flash-lite-001", "gryphe/gryphe-mistral-7b-instruct-v2", "mistralai/mistral-7b-instruct"]
             for model in fallback_models:
                 payload = {"model": model, "messages": messages, "temperature": 0.1, "max_tokens": 150}
-                for _ in range(2): 
+                payload["reasoning"] = {"enabled": True}
+                for _ in range(2):
                     try:
                         async with aiohttp.ClientSession() as session:
                             async with session.post("https://openrouter.ai/api/v1/chat/completions", headers=headers, json=payload, timeout=45) as response:


### PR DESCRIPTION
## Summary
- ensure OpenRouter payloads always include reasoning tokens
- apply default reasoning flag in bot, CLI, and document manager requests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892cbb9238c8326ac52b0015403dedf