### PR TITLE
feat: add GLM 4.5 model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Users can select their preferred AI model for responses:
 - **Nous: Hermes 405B**: Balanced between creativity and precision
 - **Kimi K2**: Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing (not tested much yet)
 - **Switchpoint Router**: Instantly routes your request to the best available model from Switchpoint AI's evolving library
+- **GLM-4.5**: Known for good factual accuracy and reliable reasoning
 - **Grok 3 Mini**: X.AI's efficient model for quick responses
 - **GPT-OSS 120B**: Open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Serves as an open-source alternative to o4-mini, activates 5.1B parameters per pass, runs on a single H100 with MXFP4 quantization, and supports configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output)
 

--- a/bot.py
+++ b/bot.py
@@ -3656,6 +3656,7 @@ class DiscordBot(commands.Bot):
             elif "maverick" in preferred_model: model_name = "Llama 4 Maverick"
             elif "qwen/qwq-32b" in preferred_model: model_name = "Qwen QwQ 32B"
             elif "qwen/qwen3-235b-a22b-thinking-2507" in preferred_model: model_name = "Qwen 3 235B A22B"
+            elif "z-ai/glm-4.5" in preferred_model: model_name = "GLM-4.5"
             elif "moonshotai/kimi-k2" in preferred_model: model_name = "Kimi K2"
             elif "switchpoint/router" in preferred_model: model_name = "Switchpoint Router"
             elif "eva-unit-01/eva-qwen-2.5-72b" in preferred_model: model_name = "EVA Qwen 2.5 72B"

--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -117,6 +117,9 @@ def register_commands(bot):
                 "switchpoint": [
                     "switchpoint/router",
                 ],
+                "zai": [
+                    "z-ai/glm-4.5",
+                ],
                 "storytelling": [
                     "latitudegames/wayfarer-large-70b-llama-3.3",
                     "thedrummer/anubis-pro-105b-v1"

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -397,6 +397,8 @@ def register_commands(bot):
                 model_name = "Qwen QwQ 32B"
             elif "qwen/qwen3-235b-a22b-thinking-2507" in preferred_model:
                 model_name = "Qwen 3 235B A22B"
+            elif "z-ai/glm-4.5" in preferred_model:
+                model_name = "GLM-4.5"
             elif "moonshotai/kimi-k2" in preferred_model:
                 model_name = "Kimi K2"
             elif "switchpoint/router" in preferred_model:

--- a/commands/utility_commands.py
+++ b/commands/utility_commands.py
@@ -174,6 +174,7 @@ def register_commands(bot):
         app_commands.Choice(name="Qwen 3 235B A22B", value="qwen/qwen3-235b-a22b-thinking-2507"),
         app_commands.Choice(name="DeepSeek V3 0324", value="deepseek/deepseek-chat-v3-0324:floor"), # Added as per request
         app_commands.Choice(name="DeepSeek-R1", value="deepseek/deepseek-r1-0528"),
+        app_commands.Choice(name="GLM-4.5", value="z-ai/glm-4.5"),
         app_commands.Choice(name="Claude 3.5 Haiku", value="anthropic/claude-3.5-haiku"),
         app_commands.Choice(name="Claude 4 Sonnet", value="anthropic/claude-sonnet-4"),
         app_commands.Choice(name="Nous: Hermes 405B", value="nousresearch/hermes-3-llama-3.1-405b"),
@@ -232,6 +233,8 @@ def register_commands(bot):
                 model_name = "Qwen QwQ 32B"
             elif "qwen/qwen3-235b-a22b-thinking-2507" in model:
                 model_name = "Qwen 3 235B A22B"
+            elif "z-ai/glm-4.5" in model:
+                model_name = "GLM-4.5"
             elif "moonshotai/kimi-k2" in model:
                 model_name = "Kimi K2"
             elif "switchpoint/router" in model:
@@ -270,6 +273,7 @@ def register_commands(bot):
                     f"**MiniMax M1**: __RECOMMENDED__ A large-scale, open-weight reasoning model from MiniMax, good for general tasks and long-context understanding. Great for finding accurate information. Good prompt adherence and an interesting personality. Uses ({bot.config.get_top_k_for_model('minimax/minimax-m1')}) search results.",
                     f"**Kimi K2**: __RECOMMENDED__ An opensource Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing and accuracy. Uses ({bot.config.get_top_k_for_model('moonshotai/kimi-k2')}) search results.",
                     f"**Switchpoint Router**: Instantly routes requests to the optimal model from Switchpoint AI's evolving library. Uses ({bot.config.get_top_k_for_model('switchpoint/router')}) search results.",
+                    f"**GLM-4.5**: __RECOMMENDED__ - Known for good factual accuracy and reliable responses. Uses ({bot.config.get_top_k_for_model('z-ai/glm-4.5')}) search results.",
                     f"**Gemini 2.5 Flash**: - Fine for prompt adherence, accurate citations, image viewing capabilities, and fast response times. Prone to hallucinating if asked about something not in it's supplied documents. Uses more search results ({bot.config.get_top_k_for_model('google/gemini-2.5-flash:thinking')}).",
                     #f"**Gemini 2.5 Pro**: (admin only) Uses ({bot.config.get_top_k_for_model('google/gemini-2.5-pro')}) search results.",
                     f"**Qwen QwQ 32B**: __RECOMMENDED__ - Great for roleplaying and creativity with strong factual accuracy and in-character immersion. Produces detailed, nuanced responses with structured formatting. Uses ({bot.config.get_top_k_for_model('qwen/qwq-32b')}) search results.",
@@ -339,6 +343,8 @@ def register_commands(bot):
                 model_name = "Qwen QwQ 32B"
             elif "qwen/qwen3-235b-a22b-thinking-2507" in preferred_model:
                 model_name = "Qwen 3 235B A22B"
+            elif "z-ai/glm-4.5" in preferred_model:
+                model_name = "GLM-4.5"
             elif "moonshotai/kimi-k2" in preferred_model:
                 model_name = "Kimi K2"
             elif "switchpoint/router" in preferred_model:
@@ -375,6 +381,7 @@ def register_commands(bot):
                     f"**MiniMax M1**: __RECOMMENDED__ A large-scale, open-weight reasoning model from MiniMax, good for general tasks and long-context understanding. Great for finding accurate information. Good prompt adherence and an interesting personality. Uses ({bot.config.get_top_k_for_model('minimax/minimax-m1')}) search results.",
                     f"**Kimi K2**: __RECOMMENDED__ An opensource Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing and accuracy. Uses ({bot.config.get_top_k_for_model('moonshotai/kimi-k2')}) search results.",
                     f"**Switchpoint Router**: Instantly routes requests to the optimal model from Switchpoint AI's evolving library. Uses ({bot.config.get_top_k_for_model('switchpoint/router')}) search results.",
+                    f"**GLM-4.5**: __RECOMMENDED__ - Known for good factual accuracy and reliable responses. Uses ({bot.config.get_top_k_for_model('z-ai/glm-4.5')}) search results.",
                     f"**Gemini 2.5 Flash**: - Fine for prompt adherence, accurate citations, image viewing capabilities, and fast response times. Prone to hallucinating if asked about something not in it's supplied documents. Uses more search results ({bot.config.get_top_k_for_model('google/gemini-2.5-flash:thinking')}).",
                     #f"**Gemini 2.5 Pro**: (admin only) Uses ({bot.config.get_top_k_for_model('google/gemini-2.5-pro')}) search results.",
                     f"**Qwen QwQ 32B**: __RECOMMENDED__ - Great for roleplaying and creativity with strong factual accuracy and in-character immersion. Produces detailed, nuanced responses with structured formatting. Uses ({bot.config.get_top_k_for_model('qwen/qwq-32b')}) search results.",

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -169,6 +169,7 @@ Users can choose their preferred AI model:
 - **Nous: Hermes 405B**: Balanced between creativity and precision
 - **Kimi K2**: Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing (not tested much yet)
 - **Switchpoint Router**: Instantly routes your request to the optimal AI from an ever-evolving library
+- **GLM-4.5**: Known for good factual accuracy and reliable reasoning
 - **Wayfarer 70B**: Optimized for narrative-driven roleplay
 - **Grok 3 Mini**: X.AI's efficient model for quick responses
 - **GPT-OSS 120B**: Open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Functions as an open-source alternative to o4-mini, activating 5.1B parameters per pass, running on a single H100 with native MXFP4 quantization, and supporting configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output generation)

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -160,6 +160,7 @@ Users can choose their preferred AI model:
 - **Nous: Hermes 405B**: Balanced between creativity and precision
 - **Kimi K2**: Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing (not tested much yet)
 - **Switchpoint Router**: Instantly routes your request to the optimal AI from an ever-evolving library
+- **GLM-4.5**: Known for good factual accuracy and reliable reasoning
 - **Wayfarer 70B**: Optimized for narrative-driven roleplay
 - **Grok 3 Mini**: X.AI's efficient model for quick responses
 - **GPT-OSS 120B**: Open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Functions as an open-source alternative to o4-mini, activating 5.1B parameters per pass, running on a single H100 with native MXFP4 quantization, and supporting configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output generation)

--- a/managers/config.py
+++ b/managers/config.py
@@ -93,6 +93,8 @@ class Config:
             "minimax/minimax-m1": 20,
             # Moonshot AI Models
             "moonshotai/kimi-k2": 20,
+            # Zhipu AI Models
+            "z-ai/glm-4.5": 20,
             "switchpoint/router": 12,
         }
         


### PR DESCRIPTION
## Summary
- add `z-ai/glm-4.5` as a selectable model with friendly name and description
- recognize GLM-4.5 across bot, query, utility, and admin features
- document GLM-4.5 as a high factual accuracy option

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892ce00df4c8326b11f8e97cd6ba32a