### PR TITLE
Respect prompt mode in agentic_query

### DIFF
--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -607,7 +607,10 @@ def register_commands(bot):
                     logger.error(f"Failed to update progress message: {e}")
 
             response, actual_model = await bot.agentic_query(
-                question, model_list, progress_callback=progress_update
+                question,
+                model_list,
+                progress_callback=progress_update,
+                user_id=str(interaction.user.id),
             )
             logger.debug(
                 "Agentic query response length: %s characters",


### PR DESCRIPTION
## Summary
- let `agentic_query` pick between standard and informational system prompts based on the user's toggle
- pass the calling user's ID from the `/agentic_query` command

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892dabfcdf08326b48f98ff4c07f6b1