### PR TITLE
Log agentic query tool call traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Comprehensive tools to help troubleshoot issues:
 - Toggle debug mode to show which model generated responses
 - Export prompts to see exactly what's being sent to the models
 - Detailed logs for tracking operations and errors
+- `/agentic_query` tool call traces recorded in `tool_call_log.jsonl`
 - Performance monitoring and optimization
 
 ## Commands

--- a/bot.py
+++ b/bot.py
@@ -37,7 +37,7 @@ from utils.helpers import (
     xml_wrap,
     wrap_document,
 )
-from utils.logging import sanitize_for_logging, log_qa_pair
+from utils.logging import sanitize_for_logging, log_qa_pair, log_tool_call_trace
 from managers.keywords import KeywordManager # Added import
 # Import the docx processing function and availability flag
 from managers.documents import tag_lore_in_docx, DOCX_AVAILABLE
@@ -3087,6 +3087,7 @@ class DiscordBot(commands.Bot):
 
         max_iterations = getattr(self.config, "MAX_ITERATIONS", 50)
         actual_model = None
+        tool_call_trace: List[Dict[str, Any]] = []
 
         def describe_tool(name: str, args: Dict[str, Any]) -> str:
             if name == "list_documents":
@@ -3120,6 +3121,7 @@ class DiscordBot(commands.Bot):
                 min_response_length=0,
             )
             if not completion or not completion.get("choices"):
+                log_tool_call_trace(question, tool_call_trace)
                 return "*neural error detected!*", actual_model
 
             message = completion["choices"][0]["message"]
@@ -3142,6 +3144,7 @@ class DiscordBot(commands.Bot):
                         result = await func(**args)
                     else:
                         result = {"error": f"Unknown tool {name}"}
+                    tool_call_trace.append({"name": name, "args": args, "result": result})
                     if progress_callback:
                         try:
                             await progress_callback(summarize_tool(name, result))
@@ -3172,9 +3175,11 @@ class DiscordBot(commands.Bot):
                 continue
 
             logger.info("Agentic query completed without further tool calls")
+            log_tool_call_trace(question, tool_call_trace)
             return message.get("content", ""), actual_model
 
         logger.warning("Agentic query reached max iterations without conclusion")
+        log_tool_call_trace(question, tool_call_trace)
         return "*neural error detected!*", actual_model
 
     async def on_message(self, message: discord.Message):

--- a/tests/test_document_manager.py
+++ b/tests/test_document_manager.py
@@ -64,6 +64,7 @@ def load_document_module():
         def dummy(*args, **kwargs):
             return None
         logging_pkg.log_qa_pair = dummy
+        logging_pkg.log_tool_call_trace = dummy
         helpers_pkg.check_permissions = dummy
         helpers_pkg.is_image = lambda *a, **kw: False
         helpers_pkg.split_message = lambda msg, limit=2000: [msg]

--- a/tests/test_tool_call_logging.py
+++ b/tests/test_tool_call_logging.py
@@ -1,0 +1,27 @@
+import json
+import importlib.util
+from pathlib import Path
+
+
+def load_logging_module():
+    """Load the actual utils.logging module regardless of sys.modules hacks."""
+    module_path = Path(__file__).resolve().parents[1] / "utils" / "logging.py"
+    spec = importlib.util.spec_from_file_location("_real_logging", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_log_tool_call_trace(tmp_path, monkeypatch):
+    logging_pkg = load_logging_module()
+    log_file = tmp_path / "tool_calls.jsonl"
+    monkeypatch.setattr(logging_pkg, "TOOL_CALL_LOG_FILE", str(log_file))
+    logging_pkg.log_tool_call_trace(
+        "What is Foo?",
+        [{"name": "search_documents", "args": {"query": "Foo"}, "result": {"items": [1, 2]}}],
+    )
+    assert log_file.exists()
+    with open(log_file, "r", encoding="utf-8") as f:
+        entry = json.loads(f.readline())
+    assert entry["question"] == "What is Foo?"
+    assert entry["tool_calls"][0]["name"] == "search_documents"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,6 +4,7 @@ from .logging import (
     display_startup_banner,
     sanitize_for_logging,
     log_qa_pair,
+    log_tool_call_trace,
 )
 from .helpers import check_permissions, is_image, split_message
 
@@ -12,6 +13,7 @@ __all__ = [
     'display_startup_banner',
     'sanitize_for_logging',
     'log_qa_pair',
+    'log_tool_call_trace',
     'check_permissions',
     'is_image',
     'split_message'


### PR DESCRIPTION
## Summary
- log `/agentic_query` tool calls to `tool_call_log.jsonl`
- expose tool call logging helper and wire into agentic query flow
- document and test tool call trace logging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892f706294083268ac1c11e8c130bfd