### PR TITLE
feat: add gpt-5-mini model

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ GOOGLE_API_KEY=your_google_api_key
 LLM_MODEL=google/gemini-2.5-flash # Default model for text generation
 DEFAULT_MODEL=qwen/qwq-32b # Default user preference model
 CLASSIFIER_MODEL=google/gemini-2.5-flash # Model for classification tasks
-AGENTIC_MODEL=openai/o4-mini # Primary model for agentic queries; fallbacks: o4-mini, gpt-oss-120b
+AGENTIC_MODEL=openai/o4-mini # Primary model for agentic queries; fallbacks: gpt-5-mini, o4-mini, gpt-oss-120b
 EMBEDDING_MODEL=models/text-embedding-004 # Model for document embeddings
 EMBEDDING_DIMENSIONS=0 # Set to positive number to truncate embeddings (0 = no truncation)
 
@@ -139,7 +139,7 @@ Users can select their preferred AI model for responses:
 - **Switchpoint Router**: Instantly routes your request to the best available model from Switchpoint AI's evolving library
 - **GLM-4.5**: Known for good factual accuracy and reliable reasoning
 - **Grok 3 Mini**: X.AI's efficient model for quick responses
-- **GPT-OSS 120B**: Open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Serves as an open-source alternative to o4-mini, activates 5.1B parameters per pass, runs on a single H100 with MXFP4 quantization, and supports configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output)
+- **GPT-OSS 120B**: Open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Serves as an open-source alternative to gpt-5-mini and o4-mini, activates 5.1B parameters per pass, runs on a single H100 with MXFP4 quantization, and supports configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output)
 
 Additional admin-only models include Gemini 2.5 Pro, Claude 3.7 Sonnet, Anubis Pro 105B, Llama 4 Maverick, OpenAI GPT-4.1 models, and Phi-4 Multimodal.
 

--- a/bot.py
+++ b/bot.py
@@ -108,6 +108,7 @@ class DiscordBot(commands.Bot):
             "meta-llama/llama-4-maverick:floor",
             "openai/gpt-4.1-mini",
             "openai/gpt-4.1-nano",
+            "openai/gpt-5-mini",
             "openai/o4-mini",
         ]
 
@@ -1413,6 +1414,11 @@ class DiscordBot(commands.Bot):
                         "openai/gpt-4.1-nano",
                     ]
                     models_to_try.extend([fb for fb in fallbacks if fb not in models_to_try])
+                elif "gpt-5-mini" in model:
+                    fallbacks = [
+                        "openai/gpt-5-mini",
+                    ]
+                    models_to_try.extend([fb for fb in fallbacks if fb not in models_to_try])
                 elif "o4-mini" in model:
                     fallbacks = [
                         "openai/o4-mini",
@@ -1436,6 +1442,7 @@ class DiscordBot(commands.Bot):
             general_fallbacks = [
                 # "qwen/qwq-32b",
                 "openai/gpt-oss-120b",
+                "openai/gpt-5-mini",
                 "openai/o4-mini",
                 "qwen/qwq-32b:floor",
                 "google/gemini-2.5-flash",
@@ -3817,6 +3824,8 @@ class DiscordBot(commands.Bot):
                 model_name = "4.1 Nano"
             elif preferred_model == "minimax/minimax-m1":
                 model_name = "MiniMax M1"
+            elif preferred_model == "openai/gpt-5-mini":
+                model_name = "OpenAI GPT-5 Mini"
             elif preferred_model == "openai/o4-mini":
                 model_name = "OpenAI o4 Mini"
             elif preferred_model == "openai/gpt-oss-120b":

--- a/commands/admin_commands.py
+++ b/commands/admin_commands.py
@@ -107,6 +107,7 @@ def register_commands(bot):
                     "nousresearch/hermes-3-llama-3.1-405b",
                 ],
                 "openai": [
+                    "openai/gpt-5-mini",
                     "openai/o4-mini",
                     "openai/gpt-oss-120b",
                 ],

--- a/commands/query_commands.py
+++ b/commands/query_commands.py
@@ -421,6 +421,8 @@ def register_commands(bot):
                 model_name = "OpenAI GPT-4.1 Mini"
             elif preferred_model == "openai/gpt-4.1-nano":
                 model_name = "OpenAI GPT-4.1 Nano"
+            elif preferred_model == "openai/gpt-5-mini":
+                model_name = "OpenAI GPT-5 Mini"
             elif preferred_model == "openai/o4-mini":
                 model_name = "OpenAI o4 Mini"
             elif preferred_model == "openai/gpt-oss-120b":
@@ -577,8 +579,8 @@ def register_commands(bot):
                 question,
             )
 
-            # Use configured agentic model with fallbacks to o4-mini and gpt-oss-120b
-            model_list = [bot.config.AGENTIC_MODEL, "z-ai/glm-4.5-air", "openai/gpt-oss-120b", "openai/o4-mini", "z-ai/glm-4.5", "qwen/qwen3-235b-a22b-thinking-2507"]
+            # Use configured agentic model with fallbacks to gpt-5-mini, o4-mini and gpt-oss-120b
+            model_list = [bot.config.AGENTIC_MODEL, "z-ai/glm-4.5-air", "openai/gpt-5-mini", "openai/gpt-oss-120b", "openai/o4-mini", "z-ai/glm-4.5", "qwen/qwen3-235b-a22b-thinking-2507"]
             model_list = list(dict.fromkeys(model_list))
             logger.debug(
                 "Using model list %s for agentic query from user %s",

--- a/commands/utility_commands.py
+++ b/commands/utility_commands.py
@@ -163,6 +163,7 @@ def register_commands(bot):
     @bot.tree.command(name="set_model", description="Set your preferred AI model for responses")
     @app_commands.describe(model="Choose the AI model you prefer")
     @app_commands.choices(model=[
+        app_commands.Choice(name="OpenAI GPT-5 Mini", value="openai/gpt-5-mini"),
         app_commands.Choice(name="OpenAI o4 Mini", value="openai/o4-mini"),
         app_commands.Choice(name="GPT-OSS 120B", value="openai/gpt-oss-120b"),
         app_commands.Choice(name="MiniMax M1", value="minimax/minimax-m1"),
@@ -257,6 +258,8 @@ def register_commands(bot):
                 model_name = "OpenAI GPT-4.1 Mini"
             elif model == "openai/gpt-4.1-nano":
                 model_name = "OpenAI GPT-4.1 Nano"
+            elif model == "openai/gpt-5-mini":
+                model_name = "OpenAI GPT-5 Mini"
             elif model == "openai/gpt-oss-120b":
                 model_name = "GPT-OSS 120B"
             elif model == "openai/o4-mini":
@@ -269,6 +272,7 @@ def register_commands(bot):
                 # Create a description of all model strengths
                 model_descriptions = [
                     f"**GPT-OSS 120B**: __RECOMMENDED__ An open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Great for factual accuracy, avoiding hallucinations, understanding, and speed of response. Not great at formatting its responses. Uses ({bot.config.get_top_k_for_model('openai/gpt-oss-120b')}) search results.",
+                    f"**OpenAI GPT-5 Mini**: __RECOMMENDED__ An OpenAI model that is very good for factual accuracy, avoiding hallucinations, and speed of response. Uses ({bot.config.get_top_k_for_model('openai/gpt-5-mini')}) search results.",
                     f"**OpenAI o4 Mini**: __RECOMMENDED__ An OpenAI model that is very good for factual accuracy, avoiding hallucinations, and speed of response. Uses ({bot.config.get_top_k_for_model('openai/o4-mini')}) search results.",
                     f"**MiniMax M1**: __RECOMMENDED__ A large-scale, open-weight reasoning model from MiniMax, good for general tasks and long-context understanding. Great for finding accurate information. Good prompt adherence and an interesting personality. Uses ({bot.config.get_top_k_for_model('minimax/minimax-m1')}) search results.",
                     f"**Kimi K2**: __RECOMMENDED__ An opensource Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing and accuracy. Uses ({bot.config.get_top_k_for_model('moonshotai/kimi-k2')}) search results.",
@@ -367,6 +371,8 @@ def register_commands(bot):
                 model_name = "OpenAI GPT-4.1 Mini"
             elif preferred_model == "openai/gpt-4.1-nano":
                 model_name = "OpenAI GPT-4.1 Nano"
+            elif preferred_model == "openai/gpt-5-mini":
+                model_name = "OpenAI GPT-5 Mini"
             elif preferred_model == "openai/gpt-oss-120b":
                 model_name = "GPT-OSS 120B"
             elif preferred_model == "openai/o4-mini":
@@ -377,6 +383,7 @@ def register_commands(bot):
             # Create a description of all model strengths
             model_descriptions = [
                     f"**GPT-OSS 120B**: __RECOMMENDED__ An open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Great for factual accuracy, avoiding hallucinations, understanding, and speed of response. Not great at formatting its responses. Uses ({bot.config.get_top_k_for_model('openai/gpt-oss-120b')}) search results.",
+                    f"**OpenAI GPT-5 Mini**: __RECOMMENDED__ An OpenAI model that is very good for factual accuracy, avoiding hallucinations, and speed of response. Uses ({bot.config.get_top_k_for_model('openai/gpt-5-mini')}) search results.",
                     f"**OpenAI o4 Mini**: __RECOMMENDED__ An OpenAI model that is very good for factual accuracy, avoiding hallucinations, and speed of response. Uses ({bot.config.get_top_k_for_model('openai/o4-mini')}) search results.",
                     f"**MiniMax M1**: __RECOMMENDED__ A large-scale, open-weight reasoning model from MiniMax, good for general tasks and long-context understanding. Great for finding accurate information. Good prompt adherence and an interesting personality. Uses ({bot.config.get_top_k_for_model('minimax/minimax-m1')}) search results.",
                     f"**Kimi K2**: __RECOMMENDED__ An opensource Large-scale Mixture-of-Experts model from Moonshot AI with 1 trillion parameters (32B active per forward pass), great for creative writing and accuracy. Uses ({bot.config.get_top_k_for_model('moonshotai/kimi-k2')}) search results.",

--- a/documentation/Publicia Documentation.md
+++ b/documentation/Publicia Documentation.md
@@ -172,7 +172,7 @@ Users can choose their preferred AI model:
 - **GLM-4.5**: Known for good factual accuracy and reliable reasoning
 - **Wayfarer 70B**: Optimized for narrative-driven roleplay
 - **Grok 3 Mini**: X.AI's efficient model for quick responses
-- **GPT-OSS 120B**: Open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Functions as an open-source alternative to o4-mini, activating 5.1B parameters per pass, running on a single H100 with native MXFP4 quantization, and supporting configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output generation)
+- **GPT-OSS 120B**: Open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Functions as an open-source alternative to gpt-5-mini and o4-mini, activating 5.1B parameters per pass, running on a single H100 with native MXFP4 quantization, and supporting configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output generation)
 
 Additional models available to administrators include Gemini 2.5 Pro, Claude 3.7 Sonnet, Anubis Pro 105B, Llama 4 Maverick, OpenAI GPT-4.1 models, and Phi-4 Multimodal.
 
@@ -270,7 +270,7 @@ GOOGLE_API_KEY=your_google_api_key
 LLM_MODEL=google/gemini-2.5-flash # Default model for text generation
 DEFAULT_MODEL=qwen/qwq-32b # Default user preference model
 CLASSIFIER_MODEL=google/gemini-2.5-flash # Model for classification tasks
-AGENTIC_MODEL=openai/o4-mini # Primary model for agentic queries; fallbacks: o4-mini, gpt-oss-120b
+AGENTIC_MODEL=openai/o4-mini # Primary model for agentic queries; fallbacks: gpt-5-mini, o4-mini, gpt-oss-120b
 EMBEDDING_MODEL=models/text-embedding-004 # Model for document embeddings
 EMBEDDING_DIMENSIONS=0 # Set to positive number to truncate embeddings (0 = no truncation)
 

--- a/documentation/Publicia Documentation.txt
+++ b/documentation/Publicia Documentation.txt
@@ -163,7 +163,7 @@ Users can choose their preferred AI model:
 - **GLM-4.5**: Known for good factual accuracy and reliable reasoning
 - **Wayfarer 70B**: Optimized for narrative-driven roleplay
 - **Grok 3 Mini**: X.AI's efficient model for quick responses
-- **GPT-OSS 120B**: Open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Functions as an open-source alternative to o4-mini, activating 5.1B parameters per pass, running on a single H100 with native MXFP4 quantization, and supporting configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output generation)
+- **GPT-OSS 120B**: Open-weight 117B-parameter Mixture-of-Experts model from OpenAI. Functions as an open-source alternative to gpt-5-mini and o4-mini, activating 5.1B parameters per pass, running on a single H100 with native MXFP4 quantization, and supporting configurable reasoning depth, full chain-of-thought access, and native tool use (function calling, browsing, structured output generation)
 
 Additional models available to administrators include Gemini 2.5 Pro, Claude 3.7 Sonnet, Anubis Pro 105B, Llama 4 Maverick, OpenAI GPT-4.1 models, and Phi-4 Multimodal.
 
@@ -261,7 +261,7 @@ GOOGLE_API_KEY=your_google_api_key
 LLM_MODEL=google/gemini-2.5-flash # Default model for text generation
 DEFAULT_MODEL=qwen/qwq-32b # Default user preference model
 CLASSIFIER_MODEL=google/gemini-2.5-flash # Model for classification tasks
-AGENTIC_MODEL=openai/o4-mini # Primary model for agentic queries; fallbacks: o4-mini, gpt-oss-120b
+AGENTIC_MODEL=openai/o4-mini # Primary model for agentic queries; fallbacks: gpt-5-mini, o4-mini, gpt-oss-120b
 EMBEDDING_MODEL=models/text-embedding-004 # Model for document embeddings
 EMBEDDING_DIMENSIONS=0 # Set to positive number to truncate embeddings (0 = no truncation)
 

--- a/managers/config.py
+++ b/managers/config.py
@@ -85,6 +85,7 @@ class Config:
             # OpenAI Models
             "openai/gpt-4.1-mini": 11,
             "openai/gpt-4.1-nano": 17,
+            "openai/gpt-5-mini": 8,
             "openai/o4-mini": 8,
             "openai/gpt-oss-120b": 18,
             # X AI Models


### PR DESCRIPTION
## Summary
- add OpenAI GPT-5 Mini as selectable model and handle friendly naming
- expand bot fallbacks and vision support to include gpt-5-mini
- document gpt-5-mini model and update configuration examples

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894f64887448326b94fdf3ac00daf90